### PR TITLE
Convert Configurator CLI from C# to PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,169 +1,62 @@
 # Configurator
 
-A Windows machine configuration tool written in PowerShell. Reads a manifest repo containing app definitions and installs, upgrades, verifies, configures, and backs up each app.
-
-Requires **PowerShell 7+** (PowerShell Core) and must be run as **Administrator**.
-
-## Quick Start
-
-### Bootstrap a Fresh Machine
-
-Run this from an elevated Windows PowerShell prompt to install Configurator, set the manifest repo, initialize the system, and configure all apps:
+A Windows machine configuration tool. PowerShell 7.0+ module, must be run as Administrator.
 
 ```powershell
-$bootstrapStopwatch = [Diagnostics.Stopwatch]::StartNew()
 Set-ExecutionPolicy RemoteSigned -Force
 
 # Download and install the Configurator module
-Invoke-Expression (Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dannydwarren/configurator/main/configurator-pwsh/Install-Configurator.ps1' -UseBasicParsing).Content
+irm https://raw.githubusercontent.com/dannydwarren/configurator/main/configurator-pwsh/Install-Configurator.ps1 | iex
 
 # Restart PATH so the module is available
 $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
 $env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('PSModulePath', 'User')
 
-Import-Module Configurator
-
 # Configure and run
-pwsh -File C:\Configurator\src\Configurator.ps1 settings set manifest.repo "https://github.com/dannydwarren/machine-configs.git"
-pwsh -File C:\Configurator\src\Configurator.ps1 initialize
-pwsh -File C:\Configurator\src\Configurator.ps1 configure --environments "All"
-
-$bootstrapStopwatch.Stop()
-Write-Output "Total duration: $($bootstrapStopwatch.Elapsed)"
+Configurator.ps1 settings set manifest.repo "https://github.com/dannydwarren/machine-configs.git"
+Configurator.ps1 initialize
+Configurator.ps1 configure --environments "All"
 ```
 
-### Install from GitHub Release
-
-```powershell
-# Run as Administrator
-irm https://raw.githubusercontent.com/dannydwarren/configurator/main/configurator-pwsh/Install-Configurator.ps1 | iex
-```
-
-This downloads the latest release zip, extracts to `C:\Configurator`, and adds it to the machine PATH and PSModulePath.
-
-### Install from Source
-
-```powershell
-git clone https://github.com/dannydwarren/configurator.git C:\src\configurator
-Import-Module C:\src\configurator\configurator-pwsh\src\Configurator.psd1
-```
-
-## CLI Usage
-
-All commands must be run as Administrator.
+## CLI Commands
 
 ```
 Configurator.ps1 <command> [options]
 ```
 
-### Commands
+| Command | Description |
+|---------|-------------|
+| `initialize` | Run system initialization (execution policies, winget, PS Core, scoop, git) and clone manifest repo |
+| `configure-machine` | Install/upgrade/configure apps from manifest. Alias: `configure` |
+| `settings list` | Display all settings |
+| `settings set <name> <value>` | Update a setting (e.g. `manifest.repo`, `git.clonedirectory`) |
+| `add-app` | Add a new app to the manifest. Alias: `add` |
+| `backup` | Run backup scripts for all installed apps |
 
-#### `initialize`
-
-Runs system initialization prerequisites (execution policies, winget, PowerShell Core, scoop, git) and clones the manifest repo.
-
-```powershell
-.\Configurator.ps1 initialize
-```
-
-#### `configure-machine` (alias: `configure`)
-
-Installs, upgrades, and configures apps from the manifest.
-
-```powershell
-# Configure all apps
-.\Configurator.ps1 configure-machine
-
-# Configure apps for specific environments
-.\Configurator.ps1 configure --environments "Work|Personal"
-.\Configurator.ps1 configure -e "Work|Personal"
-
-# Configure a single app by ID
-.\Configurator.ps1 configure --single-app-id "my-app"
-.\Configurator.ps1 configure -app "my-app"
-```
+### configure-machine options
 
 | Option | Alias | Description |
 |--------|-------|-------------|
-| `--environments` | `-e` | Pipe-separated list of environments to target |
-| `--single-app-id` | `-app` | Install a single app by its ID (ignores environments) |
+| `--environments` | `-e` | Pipe-separated environment list (e.g. `"Work\|Personal"`) |
+| `--single-app-id` | `-app` | Install a single app by ID (ignores environments) |
 
-#### `settings list`
-
-Display all settings as a table.
-
-```powershell
-.\Configurator.ps1 settings list
-```
-
-#### `settings set`
-
-Update a single setting by its dotted path name.
-
-```powershell
-.\Configurator.ps1 settings set manifest.repo "https://github.com/user/machine-configs.git"
-.\Configurator.ps1 settings set manifest.filename "manifest.json"
-.\Configurator.ps1 settings set git.clonedirectory "C:\src\"
-```
-
-| Setting | Type | Default |
-|---------|------|---------|
-| `downloadsdirectory` | Uri | `C:/tmp/configurator-downloads` |
-| `manifest.repo` | Uri | *(none)* |
-| `manifest.filename` | String | `manifest.json` |
-| `manifest.directory` | String | *(set during initialize)* |
-| `git.clonedirectory` | Uri | `C:\src\` |
-
-#### `add-app` (alias: `add`)
-
-Add a new app definition to the manifest.
-
-```powershell
-.\Configurator.ps1 add-app --app-id "my-app" --app-type "winget" --environments "Work|Personal"
-.\Configurator.ps1 add --app-id "my-app" --app-type "scoop" --environments "All"
-```
+### add-app options
 
 | Option | Description |
 |--------|-------------|
-| `--app-id` | The app identifier |
-| `--app-type` | The installer type (see supported types below) |
+| `--app-id` | App identifier |
+| `--app-type` | Installer type: `winget`, `scoop`, `scoopBucket`, `powerShell`, `powerShellModule`, `powerShellAppPackage`, `script`, `gitRepo`, `gitconfig`, `nonPackageApp`, `visualStudioExtension` |
 | `--environments` | Pipe-separated environment list |
 
-Supported app types: `winget`, `scoop`, `scoopBucket`, `powerShell`, `powerShellModule`, `powerShellAppPackage`, `script`, `gitRepo`, `gitconfig`, `nonPackageApp`, `visualStudioExtension`
-
-#### `backup`
-
-Run backup scripts for all installed apps that have a `backup.ps1` in their manifest directory.
-
-```powershell
-.\Configurator.ps1 backup
-```
-
-### Exit Codes
+### Exit codes
 
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | Generic failure (invalid args, command error) |
+| 1 | Generic failure |
 | 2 | Not running as Administrator |
 
-## Module Functions
-
-When imported as a module, the following functions are available:
-
-| Function | Description |
-|----------|-------------|
-| `Start-Configurator` | CLI entry point (argument parsing and routing) |
-| `Invoke-Initialize` | Run system initialization |
-| `Invoke-ConfigureMachine` | Install/configure apps from manifest |
-| `Get-ConfiguratorSettings` | List all settings |
-| `Set-ConfiguratorSetting` | Update a setting |
-| `Add-ConfiguratorApp` | Add an app to the manifest |
-| `Invoke-Backup` | Back up all installed apps |
-
 ## Manifest Format
-
-The manifest repo contains:
 
 ```
 manifest.json          # List of app IDs
@@ -178,39 +71,11 @@ apps/
 
 ## Development
 
-### Running Tests
-
 ```powershell
 cd configurator-pwsh
 Invoke-Pester -Path tests/ -Output Detailed
 ```
 
-### Project Structure
-
-```
-configurator-pwsh/
-  src/
-    Configurator.ps1       # CLI entry point
-    Configurator.psd1      # Module manifest
-    Configurator.psm1      # Module loader
-    Public/                 # Exported command functions
-    Private/                # Internal functions
-      AppTypes/             # App type parsers (12 types)
-      Downloaders/          # GitHub asset, VS extension downloaders
-      Initializer/          # System initialization steps
-      Installer/            # Install/upgrade/configure/backup logic
-      Manifest/             # Manifest loading and saving
-      PowerShell/           # Script execution wrappers
-      Registry/             # Windows registry operations
-      Settings/             # Settings persistence
-      Utilities/            # Logging, tokens, desktop cleanup, etc.
-  tests/
-    Unit/                   # Pester unit tests
-    Integration/            # Pester integration tests
-  spec/                     # Behavior specification docs
-  Install-Configurator.ps1 # Bootstrap installer script
-```
-
 ## Previous C# Version
 
-This tool was rewritten from C# to PowerShell. The original C# README is archived at [archive/README-csharp.md](archive/README-csharp.md).
+For the previous C# implementation, see [archive/README-csharp.md](archive/README-csharp.md).

--- a/README.md
+++ b/README.md
@@ -1,48 +1,216 @@
-﻿# configurator
+# Configurator
+
+A Windows machine configuration tool written in PowerShell. Reads a manifest repo containing app definitions and installs, upgrades, verifies, configures, and backs up each app.
+
+Requires **PowerShell 7+** (PowerShell Core) and must be run as **Administrator**.
+
+## Quick Start
+
+### Bootstrap a Fresh Machine
+
+Run this from an elevated Windows PowerShell prompt to install Configurator, set the manifest repo, initialize the system, and configure all apps:
 
 ```powershell
 $bootstrapStopwatch = [Diagnostics.Stopwatch]::StartNew()
 Set-ExecutionPolicy RemoteSigned -Force
 
-Invoke-Command {
-    $asset = (iwr -useb https://api.github.com/repos/dannydwarren/configurator/releases/latest | ConvertFrom-Json).assets | ? { $_.name -like "*.exe" }
-    $downloadUrl = $asset | select -exp browser_download_url
-    Start-BitsTransfer -Source $downloadUrl -Destination "$HOME\Downloads\Configurator.exe"
-}
-$downloadDuration = $bootstrapStopwatch.Elapsed
-Write-Output "Download duration: $($downloadDuration)"
+# Download and install the Configurator module
+Invoke-Expression (Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/dannydwarren/configurator/main/configurator-pwsh/Install-Configurator.ps1' -UseBasicParsing).Content
 
-$bootstrapStopwatch.Restart()
-."$HOME\Downloads\Configurator.exe" settings set manifest.repo "https://github.com/dannydwarren/machine-configs.git"
-."$HOME\Downloads\Configurator.exe" initialize
-."$HOME\Downloads\Configurator.exe" configure --environments "All"
-Write-Output "Download duration: $($downloadDuration)"
-$bootstrapDuration = $bootstrapStopwatch.Elapsed
-Write-Output "Configurator duration: $($bootstrapDuration)"
-$totalDuration = $downloadDuration + $bootstrapDuration
-Write-Output "Total duration: $($totalDuration)"
+# Restart PATH so the module is available
+$env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path', 'User')
+$env:PSModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine') + ';' + [System.Environment]::GetEnvironmentVariable('PSModulePath', 'User')
+
+Import-Module Configurator
+
+# Configure and run
+pwsh -File C:\Configurator\src\Configurator.ps1 settings set manifest.repo "https://github.com/dannydwarren/machine-configs.git"
+pwsh -File C:\Configurator\src\Configurator.ps1 initialize
+pwsh -File C:\Configurator\src\Configurator.ps1 configure --environments "All"
+
 $bootstrapStopwatch.Stop()
+Write-Output "Total duration: $($bootstrapStopwatch.Elapsed)"
 ```
 
-# Local Development
-Run `.\Scripts\00_setup.ps1` to add supporting commands to your $profile.
-- Configures a fixed path for local deployment
-- Adds fixed path for deployment to the running window's PATH
+### Install from GitHub Release
 
-Calling the function `configurator-publish` publishes to the fixed path.
+```powershell
+# Run as Administrator
+irm https://raw.githubusercontent.com/dannydwarren/configurator/main/configurator-pwsh/Install-Configurator.ps1 | iex
+```
 
-You can now run `Configurator.exe` from any path.
+This downloads the latest release zip, extracts to `C:\Configurator`, and adds it to the machine PATH and PSModulePath.
 
-# Non-NuGet Dependencies
+### Install from Source
 
-## Emmersion.Http
-Source: https://github.com/emmersion/Emmersion.Http
+```powershell
+git clone https://github.com/dannydwarren/configurator.git C:\src\configurator
+Import-Module C:\src\configurator\configurator-pwsh\src\Configurator.psd1
+```
 
-Justification: The package put out by Emmersion as of July 20, 2021 targets `netcoreapp3.1`. I want to consume a `netstandard2.1` version for flexibility.
+## CLI Usage
 
-# Debugging Notes
+All commands must be run as Administrator.
 
-## xunit Console Logging
-One of the things that makes testing difficult is that xunit does automatically write `Console.WriteLine()` statements to the test output. It also does not write to the debug console when debugging tests. I have found that when using JetBrains Rider in my setup on Windows it writes the test output to this directory `~\AppData\Local\JetBrains\Rider2021.3\log\UnitTestLogs\Sessions`. Obviously that will change based on the version of Rider.
+```
+Configurator.ps1 <command> [options]
+```
 
-One of my goals is to build a way for xunit to output to a `List<string>` so it can be analyzed at test assertion time. For a CLI tool this seems like an important thing to be able to test. If you know how to do this please feel free to reach out or submit a PR. 😁 Cheers!
+### Commands
+
+#### `initialize`
+
+Runs system initialization prerequisites (execution policies, winget, PowerShell Core, scoop, git) and clones the manifest repo.
+
+```powershell
+.\Configurator.ps1 initialize
+```
+
+#### `configure-machine` (alias: `configure`)
+
+Installs, upgrades, and configures apps from the manifest.
+
+```powershell
+# Configure all apps
+.\Configurator.ps1 configure-machine
+
+# Configure apps for specific environments
+.\Configurator.ps1 configure --environments "Work|Personal"
+.\Configurator.ps1 configure -e "Work|Personal"
+
+# Configure a single app by ID
+.\Configurator.ps1 configure --single-app-id "my-app"
+.\Configurator.ps1 configure -app "my-app"
+```
+
+| Option | Alias | Description |
+|--------|-------|-------------|
+| `--environments` | `-e` | Pipe-separated list of environments to target |
+| `--single-app-id` | `-app` | Install a single app by its ID (ignores environments) |
+
+#### `settings list`
+
+Display all settings as a table.
+
+```powershell
+.\Configurator.ps1 settings list
+```
+
+#### `settings set`
+
+Update a single setting by its dotted path name.
+
+```powershell
+.\Configurator.ps1 settings set manifest.repo "https://github.com/user/machine-configs.git"
+.\Configurator.ps1 settings set manifest.filename "manifest.json"
+.\Configurator.ps1 settings set git.clonedirectory "C:\src\"
+```
+
+| Setting | Type | Default |
+|---------|------|---------|
+| `downloadsdirectory` | Uri | `C:/tmp/configurator-downloads` |
+| `manifest.repo` | Uri | *(none)* |
+| `manifest.filename` | String | `manifest.json` |
+| `manifest.directory` | String | *(set during initialize)* |
+| `git.clonedirectory` | Uri | `C:\src\` |
+
+#### `add-app` (alias: `add`)
+
+Add a new app definition to the manifest.
+
+```powershell
+.\Configurator.ps1 add-app --app-id "my-app" --app-type "winget" --environments "Work|Personal"
+.\Configurator.ps1 add --app-id "my-app" --app-type "scoop" --environments "All"
+```
+
+| Option | Description |
+|--------|-------------|
+| `--app-id` | The app identifier |
+| `--app-type` | The installer type (see supported types below) |
+| `--environments` | Pipe-separated environment list |
+
+Supported app types: `winget`, `scoop`, `scoopBucket`, `powerShell`, `powerShellModule`, `powerShellAppPackage`, `script`, `gitRepo`, `gitconfig`, `nonPackageApp`, `visualStudioExtension`
+
+#### `backup`
+
+Run backup scripts for all installed apps that have a `backup.ps1` in their manifest directory.
+
+```powershell
+.\Configurator.ps1 backup
+```
+
+### Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Generic failure (invalid args, command error) |
+| 2 | Not running as Administrator |
+
+## Module Functions
+
+When imported as a module, the following functions are available:
+
+| Function | Description |
+|----------|-------------|
+| `Start-Configurator` | CLI entry point (argument parsing and routing) |
+| `Invoke-Initialize` | Run system initialization |
+| `Invoke-ConfigureMachine` | Install/configure apps from manifest |
+| `Get-ConfiguratorSettings` | List all settings |
+| `Set-ConfiguratorSetting` | Update a setting |
+| `Add-ConfiguratorApp` | Add an app to the manifest |
+| `Invoke-Backup` | Back up all installed apps |
+
+## Manifest Format
+
+The manifest repo contains:
+
+```
+manifest.json          # List of app IDs
+apps/
+  <app-id>/
+    app.json           # App definition (type, environments, config)
+    install.ps1        # Install script (PowerShell app type)
+    upgrade.ps1        # Upgrade script (optional)
+    verification.ps1   # Verification script (optional)
+    backup.ps1         # Backup script (optional)
+```
+
+## Development
+
+### Running Tests
+
+```powershell
+cd configurator-pwsh
+Invoke-Pester -Path tests/ -Output Detailed
+```
+
+### Project Structure
+
+```
+configurator-pwsh/
+  src/
+    Configurator.ps1       # CLI entry point
+    Configurator.psd1      # Module manifest
+    Configurator.psm1      # Module loader
+    Public/                 # Exported command functions
+    Private/                # Internal functions
+      AppTypes/             # App type parsers (12 types)
+      Downloaders/          # GitHub asset, VS extension downloaders
+      Initializer/          # System initialization steps
+      Installer/            # Install/upgrade/configure/backup logic
+      Manifest/             # Manifest loading and saving
+      PowerShell/           # Script execution wrappers
+      Registry/             # Windows registry operations
+      Settings/             # Settings persistence
+      Utilities/            # Logging, tokens, desktop cleanup, etc.
+  tests/
+    Unit/                   # Pester unit tests
+    Integration/            # Pester integration tests
+  spec/                     # Behavior specification docs
+  Install-Configurator.ps1 # Bootstrap installer script
+```
+
+## Previous C# Version
+
+This tool was rewritten from C# to PowerShell. The original C# README is archived at [archive/README-csharp.md](archive/README-csharp.md).

--- a/archive/README-csharp.md
+++ b/archive/README-csharp.md
@@ -1,0 +1,48 @@
+﻿# configurator
+
+```powershell
+$bootstrapStopwatch = [Diagnostics.Stopwatch]::StartNew()
+Set-ExecutionPolicy RemoteSigned -Force
+
+Invoke-Command {
+    $asset = (iwr -useb https://api.github.com/repos/dannydwarren/configurator/releases/latest | ConvertFrom-Json).assets | ? { $_.name -like "*.exe" }
+    $downloadUrl = $asset | select -exp browser_download_url
+    Start-BitsTransfer -Source $downloadUrl -Destination "$HOME\Downloads\Configurator.exe"
+}
+$downloadDuration = $bootstrapStopwatch.Elapsed
+Write-Output "Download duration: $($downloadDuration)"
+
+$bootstrapStopwatch.Restart()
+."$HOME\Downloads\Configurator.exe" settings set manifest.repo "https://github.com/dannydwarren/machine-configs.git"
+."$HOME\Downloads\Configurator.exe" initialize
+."$HOME\Downloads\Configurator.exe" configure --environments "All"
+Write-Output "Download duration: $($downloadDuration)"
+$bootstrapDuration = $bootstrapStopwatch.Elapsed
+Write-Output "Configurator duration: $($bootstrapDuration)"
+$totalDuration = $downloadDuration + $bootstrapDuration
+Write-Output "Total duration: $($totalDuration)"
+$bootstrapStopwatch.Stop()
+```
+
+# Local Development
+Run `.\Scripts\00_setup.ps1` to add supporting commands to your $profile.
+- Configures a fixed path for local deployment
+- Adds fixed path for deployment to the running window's PATH
+
+Calling the function `configurator-publish` publishes to the fixed path.
+
+You can now run `Configurator.exe` from any path.
+
+# Non-NuGet Dependencies
+
+## Emmersion.Http
+Source: https://github.com/emmersion/Emmersion.Http
+
+Justification: The package put out by Emmersion as of July 20, 2021 targets `netcoreapp3.1`. I want to consume a `netstandard2.1` version for flexibility.
+
+# Debugging Notes
+
+## xunit Console Logging
+One of the things that makes testing difficult is that xunit does automatically write `Console.WriteLine()` statements to the test output. It also does not write to the debug console when debugging tests. I have found that when using JetBrains Rider in my setup on Windows it writes the test output to this directory `~\AppData\Local\JetBrains\Rider2021.3\log\UnitTestLogs\Sessions`. Obviously that will change based on the version of Rider.
+
+One of my goals is to build a way for xunit to output to a `List<string>` so it can be analyzed at test assertion time. For a CLI tool this seems like an important thing to be able to test. If you know how to do this please feel free to reach out or submit a PR. 😁 Cheers!

--- a/configurator-pwsh/.github/workflows/ConfiguratorPwshCI.yml
+++ b/configurator-pwsh/.github/workflows/ConfiguratorPwshCI.yml
@@ -1,0 +1,40 @@
+name: Configurator PowerShell CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['configurator-pwsh/**']
+  pull_request:
+    branches: [main]
+    paths: ['configurator-pwsh/**']
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+
+      - name: Run Pester Tests
+        shell: pwsh
+        working-directory: configurator-pwsh
+        run: |
+          $config = New-PesterConfiguration
+          $config.Run.Path = './tests'
+          $config.Run.Exit = $true
+          $config.Output.Verbosity = 'Detailed'
+          $config.TestResult.Enabled = $true
+          $config.TestResult.OutputPath = './test-results.xml'
+          $config.TestResult.OutputFormat = 'NUnitXml'
+          Invoke-Pester -Configuration $config
+
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: configurator-pwsh/test-results.xml

--- a/configurator-pwsh/.github/workflows/ConfiguratorPwshCI.yml
+++ b/configurator-pwsh/.github/workflows/ConfiguratorPwshCI.yml
@@ -1,40 +1,36 @@
 name: Configurator PowerShell CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
-    paths: ['configurator-pwsh/**']
+    paths:
+      - 'configurator-pwsh/**'
+      - '.github/workflows/ConfiguratorPwshCI.yml'
   pull_request:
     branches: [main]
-    paths: ['configurator-pwsh/**']
+    paths:
+      - 'configurator-pwsh/**'
+      - '.github/workflows/ConfiguratorPwshCI.yml'
 
 jobs:
   test:
     runs-on: windows-latest
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Pester
         shell: pwsh
-        run: |
-          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+        run: Install-Module Pester -Force -SkipPublisherCheck
 
       - name: Run Pester Tests
         shell: pwsh
-        working-directory: configurator-pwsh
-        run: |
-          $config = New-PesterConfiguration
-          $config.Run.Path = './tests'
-          $config.Run.Exit = $true
-          $config.Output.Verbosity = 'Detailed'
-          $config.TestResult.Enabled = $true
-          $config.TestResult.OutputPath = './test-results.xml'
-          $config.TestResult.OutputFormat = 'NUnitXml'
-          Invoke-Pester -Configuration $config
+        run: Invoke-Pester -Path './configurator-pwsh/tests' -CI -Output Detailed
 
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: configurator-pwsh/test-results.xml
+          name: pester-test-results
+          path: testResults.xml

--- a/configurator-pwsh/.github/workflows/ConfiguratorPwshCICD.yml
+++ b/configurator-pwsh/.github/workflows/ConfiguratorPwshCICD.yml
@@ -1,45 +1,88 @@
 name: Configurator PowerShell CICD
 
-on:
-  push:
-    tags: ['v*']
+on: workflow_dispatch
+
+env:
+  APP_VERSION: 0.0.${{ github.run_number }}
 
 jobs:
-  test:
+  release:
     runs-on: windows-latest
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Pester
         shell: pwsh
-        run: |
-          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+        run: Install-Module Pester -Force -SkipPublisherCheck
 
       - name: Run Pester Tests
         shell: pwsh
-        working-directory: configurator-pwsh
-        run: |
-          $config = New-PesterConfiguration
-          $config.Run.Path = './tests'
-          $config.Run.Exit = $true
-          Invoke-Pester -Configuration $config
+        run: Invoke-Pester -Path './configurator-pwsh/tests' -CI -Output Detailed
 
-  package:
-    needs: test
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pester-test-results
+          path: testResults.xml
 
       - name: Package Module
         shell: pwsh
         run: |
-          $version = "${{ github.ref_name }}".TrimStart('v')
-          $stagingDir = New-Item -Path './staging/Configurator' -ItemType Directory -Force
-          Copy-Item -Path './configurator-pwsh/src/*' -Destination $stagingDir -Recurse
-          Compress-Archive -Path $stagingDir -DestinationPath "./Configurator-$version.zip"
+          $releaseDir = New-Item -Path './release/Configurator' -ItemType Directory -Force
+          Copy-Item -Path './configurator-pwsh/src/*' -Destination $releaseDir -Recurse
+          Compress-Archive -Path './release/Configurator' -DestinationPath "./Configurator-v${{ env.APP_VERSION }}.zip"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: Configurator-*.zip
-          generate_release_notes: true
+          tag_name: pwsh-v${{ env.APP_VERSION }}
+          release_name: Configurator PowerShell v${{ env.APP_VERSION }}
+          draft: false
+          prerelease: false
+          body: |
+            Configurator PowerShell module v${{ env.APP_VERSION }}
+
+      - name: Upload Release Zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./Configurator-v${{ env.APP_VERSION }}.zip
+          asset_name: Configurator-v${{ env.APP_VERSION }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload Configurator.ps1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./configurator-pwsh/src/Configurator.ps1
+          asset_name: Configurator.ps1
+          asset_content_type: text/plain
+
+      - name: Upload Configurator.psd1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./configurator-pwsh/src/Configurator.psd1
+          asset_name: Configurator.psd1
+          asset_content_type: text/plain
+
+      - name: Upload Configurator.psm1
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./configurator-pwsh/src/Configurator.psm1
+          asset_name: Configurator.psm1
+          asset_content_type: text/plain

--- a/configurator-pwsh/.github/workflows/ConfiguratorPwshCICD.yml
+++ b/configurator-pwsh/.github/workflows/ConfiguratorPwshCICD.yml
@@ -1,0 +1,45 @@
+name: Configurator PowerShell CICD
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pester
+        shell: pwsh
+        run: |
+          Install-Module -Name Pester -MinimumVersion 5.0 -Force -SkipPublisherCheck
+
+      - name: Run Pester Tests
+        shell: pwsh
+        working-directory: configurator-pwsh
+        run: |
+          $config = New-PesterConfiguration
+          $config.Run.Path = './tests'
+          $config.Run.Exit = $true
+          Invoke-Pester -Configuration $config
+
+  package:
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Package Module
+        shell: pwsh
+        run: |
+          $version = "${{ github.ref_name }}".TrimStart('v')
+          $stagingDir = New-Item -Path './staging/Configurator' -ItemType Directory -Force
+          Copy-Item -Path './configurator-pwsh/src/*' -Destination $stagingDir -Recurse
+          Compress-Archive -Path $stagingDir -DestinationPath "./Configurator-$version.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Configurator-*.zip
+          generate_release_notes: true

--- a/configurator-pwsh/ARCHITECTURE.md
+++ b/configurator-pwsh/ARCHITECTURE.md
@@ -1,0 +1,181 @@
+# Configurator PowerShell Module - Architecture
+
+## Overview
+
+Configurator is a Windows machine configuration tool rewritten from C# to pure PowerShell. It reads a manifest repo containing app definitions and installs, upgrades, verifies, and configures each app. The PowerShell version consumes the exact same manifest format as the C# version.
+
+## Module Structure
+
+This is a PowerShell script module (not binary).
+
+- **Entry point:** `Configurator.ps1` - main CLI script that users invoke directly
+- **Module:** `Configurator.psm1` + `Configurator.psd1` - importable functions for the module system
+- **Public functions:** Exported CLI commands (one function per command)
+- **Private functions:** Internal utilities not exported from the module
+
+## Directory Layout
+
+```
+configurator-pwsh/
+  spec/                              # Behavior specification docs
+    SPECIFICATION.md
+    APP_TYPES.md
+    TEST_PLAN.md
+  src/
+    Configurator.ps1                 # CLI entry point (argument parsing, routing)
+    Configurator.psd1                # Module manifest
+    Configurator.psm1                # Root module (dot-sources all functions)
+    Public/                          # Exported functions (CLI commands)
+      Invoke-Initialize.ps1
+      Invoke-ConfigureMachine.ps1
+      Get-ConfiguratorSettings.ps1
+      Set-ConfiguratorSetting.ps1
+      Add-ConfiguratorApp.ps1
+      Invoke-Backup.ps1
+    Private/                         # Internal functions
+      Settings/
+        Get-SettingsPath.ps1
+        Import-Settings.ps1
+        Export-Settings.ps1
+      Manifest/
+        Import-Manifest.ps1
+        Import-AppDefinition.ps1
+        Save-AppDefinition.ps1
+        ConvertTo-AppObject.ps1
+      Installer/
+        Install-App.ps1
+        Install-DownloadApp.ps1
+        Invoke-AppConfigurator.ps1
+      Initializer/
+        Initialize-System.ps1
+        Install-Self.ps1
+        Install-ScoopCli.ps1
+        Install-Git.ps1
+        Install-PowerShellCore.ps1
+        Install-ManifestRepo.ps1
+        Set-WingetConfiguration.ps1
+        Set-PowerShellPolicy.ps1
+      PowerShell/
+        Invoke-PowerShellScript.ps1
+        Invoke-WindowsPowerShellScript.ps1
+        New-ScriptFile.ps1
+        Find-PowerShellCore.ps1
+      Utilities/
+        Write-ConfiguratorLog.ps1
+        Resolve-Token.ps1
+        Remove-DesktopShortcuts.ps1
+        Get-Download.ps1
+        Test-Administrator.ps1
+      Downloaders/
+        Get-GitHubAsset.ps1
+        Get-VisualStudioExtension.ps1
+      Registry/
+        Get-RegistryValue.ps1
+        Set-RegistryValue.ps1
+      AppTypes/
+        New-WingetApp.ps1
+        New-ScoopApp.ps1
+        New-ScoopBucketApp.ps1
+        New-PowerShellApp.ps1
+        New-PowerShellModuleApp.ps1
+        New-PowerShellAppPackageApp.ps1
+        New-ScriptApp.ps1
+        New-GitRepoApp.ps1
+        New-GitconfigApp.ps1
+        New-NonPackageApp.ps1
+        New-VisualStudioExtensionApp.ps1
+        New-GitHubAssetApp.ps1
+  tests/
+    Unit/                            # Pester unit tests (mirror src structure)
+      Public/
+      Private/
+    Integration/                     # Pester integration tests
+      TestManifests/                 # Port from C# IntegrationTests
+    Configurator.Tests.ps1           # Pester configuration / test entry
+  .github/
+    workflows/
+      ConfiguratorPwshCI.yml         # CI: run Pester tests
+      ConfiguratorPwshCICD.yml       # CD: package and release
+```
+
+## Design Decisions
+
+### 1. CLI Argument Parsing
+
+Uses `param()` blocks with PowerShell parameter sets instead of System.CommandLine. The main `Configurator.ps1` script handles argument parsing and routes to the appropriate Public function. Each command is a separate parameter set. Aliases (`configure` for `configure-machine`, `add` for `add-app`) are implemented via parameter set names or ValidateSet attributes.
+
+### 2. No DI Container
+
+PowerShell does not need dependency injection. Functions call other functions directly. For testability, Pester's `Mock` command intercepts function calls at the function level. This gives the same isolation as constructor injection without the ceremony.
+
+### 3. App Type Pattern
+
+Each app type has a `New-<Type>App` function in `Private/AppTypes/`. These functions accept the raw JSON-parsed hashtable from `app.json` and return a standardized `[PSCustomObject]` with these properties:
+
+- `AppId`, `AppType`, `Environments`
+- `InstallScript`, `VerificationScript`, `UpgradeScript`
+- `PreventUpgrade`, `InstallArgs`, `Configuration`
+- `Downloader`, `DownloaderArgs`, `DownloadedFilePath` (for download app types)
+
+The `ConvertTo-AppObject` function acts as the discriminator/switch, routing to the correct `New-*App` function based on `appType`.
+
+### 4. Settings as PSCustomObject
+
+Settings use the same JSON format as the C# version. `ConvertFrom-Json` deserializes to `[PSCustomObject]`. `ConvertTo-Json` serializes back. Default values are constructed in `Import-Settings` when no settings file exists.
+
+Settings path: `$env:LOCALAPPDATA\Configurator\settings.json`
+
+JSON property naming uses camelCase to maintain backward compatibility with existing settings files.
+
+### 5. Logging
+
+Custom `Write-ConfiguratorLog` function with level/color mapping matching the C# spec:
+
+| Level    | Label   | Color   |
+|----------|---------|---------|
+| Debug    | DEBUG   | Gray    |
+| Verbose  | INFOV   | White   |
+| Info     | INFO    | White   |
+| Warn     | WARN    | Yellow  |
+| Error    | ERROR   | Red     |
+| Progress | PRGRS   | Blue    |
+| Result   | RESLT   | Green   |
+
+Format: `[<ISO8601>] [<LEVEL>] <message>`
+
+### 6. Error Handling
+
+`$ErrorActionPreference = 'Stop'` at the module level to ensure errors throw exceptions. Commands use `try/catch` blocks. Exit codes match the spec:
+
+| Code | Name                 |
+|------|----------------------|
+| 0    | Success              |
+| 1    | GenericFailure       |
+| 2    | NotEnoughPrivileges  |
+
+### 7. PowerShell Execution
+
+Since we ARE PowerShell, most script execution uses `Invoke-Command` with script blocks or `& operator` instead of spawning pwsh.exe processes. Scripts are still written to temp files and executed via `-File` for isolation and consistent behavior with the C# version's approach.
+
+Exception: `ForceWindowsPowerShell` scenarios still spawn `powershell.exe` explicitly. This is used during initialization when installing PowerShell Core via Windows PowerShell.
+
+The environment-ready script wrapper (PATH rebuild + `$profile` setup) is prepended to every script before execution, matching the C# behavior.
+
+### 8. Self-Install
+
+The PowerShell version downloads a zip/folder from GitHub releases containing the module, extracts to the install directory, and adds to PATH and PSModulePath. This replaces the C# .exe download mechanism.
+
+### 9. Manifest Backward Compatibility
+
+The module reads the exact same `manifest.json` and `apps/<appId>/app.json` format. JSON property names are camelCase. Environment filtering uses case-insensitive substring matching (matching the C# `Contains` behavior).
+
+### 10. Testability
+
+Every function is individually mockable via Pester. Functions accept parameters rather than reading global state directly (except settings, which are loaded via `Import-Settings`). Integration tests use real file I/O with test manifest directories copied from the C# test suite.
+
+### 11. Bug Fixes from C# Version
+
+The following C# bugs are fixed in this rewrite:
+- `ScoopBucketApp` verification script now properly interpolates the app ID
+- `VisualStudioExtensionApp` install script fixes `$vsi0xInstaller` typo to `$vsixInstaller`
+- `GitHubAssestApp` typo corrected to `GitHubAssetApp`

--- a/configurator-pwsh/Install-Configurator.ps1
+++ b/configurator-pwsh/Install-Configurator.ps1
@@ -1,0 +1,72 @@
+#Requires -RunAsAdministrator
+param(
+    [string]$InstallPath = 'C:\Configurator',
+    [string]$GitHubUser = 'dannydwarren',
+    [string]$GitHubRepo = 'configurator'
+)
+
+$ErrorActionPreference = 'Stop'
+
+Write-Host "Fetching latest PowerShell release from GitHub..."
+$releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/$GitHubUser/$GitHubRepo/releases" -Headers @{ 'User-Agent' = 'Configurator-Installer' }
+
+$pwshRelease = $releaseInfo | Where-Object { $_.tag_name -like 'pwsh-v*' } | Select-Object -First 1
+
+if (-not $pwshRelease) {
+    throw "No PowerShell release found in $GitHubUser/$GitHubRepo"
+}
+
+$zipAsset = $pwshRelease.assets | Where-Object { $_.name -like 'Configurator-v*.zip' } | Select-Object -First 1
+
+if (-not $zipAsset) {
+    throw "No zip asset found in release $($pwshRelease.tag_name)"
+}
+
+$downloadUrl = $zipAsset.browser_download_url
+$tempZip = Join-Path $env:TEMP "Configurator-latest.zip"
+
+Write-Host "Downloading $($zipAsset.name) from $($pwshRelease.tag_name)..."
+Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZip -UseBasicParsing
+
+if (Test-Path $InstallPath) {
+    Write-Host "Removing existing installation at $InstallPath..."
+    Remove-Item -Path $InstallPath -Recurse -Force
+}
+
+Write-Host "Extracting to $InstallPath..."
+$tempExtract = Join-Path $env:TEMP "Configurator-extract"
+if (Test-Path $tempExtract) {
+    Remove-Item -Path $tempExtract -Recurse -Force
+}
+Expand-Archive -Path $tempZip -DestinationPath $tempExtract -Force
+
+$extractedDir = Join-Path $tempExtract 'Configurator'
+if (Test-Path $extractedDir) {
+    Move-Item -Path $extractedDir -Destination $InstallPath -Force
+} else {
+    New-Item -Path $InstallPath -ItemType Directory -Force | Out-Null
+    Copy-Item -Path "$tempExtract\*" -Destination $InstallPath -Recurse -Force
+}
+
+$machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+if ($machinePath -notlike "*$InstallPath*") {
+    Write-Host "Adding $InstallPath to machine PATH..."
+    [System.Environment]::SetEnvironmentVariable('Path', "$machinePath;$InstallPath", 'Machine')
+}
+
+$srcPath = Join-Path $InstallPath 'src'
+if (-not (Test-Path $srcPath)) {
+    $srcPath = $InstallPath
+}
+
+$currentModulePath = [System.Environment]::GetEnvironmentVariable('PSModulePath', 'Machine')
+if ($currentModulePath -notlike "*$srcPath*") {
+    Write-Host "Adding $srcPath to machine PSModulePath..."
+    [System.Environment]::SetEnvironmentVariable('PSModulePath', "$currentModulePath;$srcPath", 'Machine')
+}
+
+Remove-Item -Path $tempZip -Force -ErrorAction SilentlyContinue
+Remove-Item -Path $tempExtract -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Host "Configurator installed to $InstallPath"
+Write-Host "Restart your shell, then run: Import-Module Configurator"

--- a/configurator-pwsh/spec/APP_TYPES.md
+++ b/configurator-pwsh/spec/APP_TYPES.md
@@ -1,0 +1,557 @@
+# App Types - Detailed Specification
+
+This document describes every app type supported by Configurator, including their JSON format, generated scripts, and special behaviors.
+
+---
+
+## Common Fields (All App Types)
+
+Every `app.json` file requires these fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `appType` | string (enum) | Yes | The app type discriminator |
+| `appId` | string | Yes | Unique identifier for the app |
+| `environments` | string | Yes | Pipe-separated environment names (e.g., `"Work\|Personal"`) |
+
+---
+
+## AppType Enum Values
+
+```
+Unknown, Script, PowerShell, PowerShellAppPackage, PowerShellModule,
+Winget, Scoop, ScoopBucket, Gitconfig, NonPackageApp,
+VisualStudioExtension, GitRepo
+```
+
+JSON serialization uses camelCase: `"winget"`, `"scoop"`, `"scoopBucket"`, `"powerShell"`, `"powerShellModule"`, `"powerShellAppPackage"`, `"script"`, `"gitconfig"`, `"nonPackageApp"`, `"visualStudioExtension"`, `"gitRepo"`, `"unknown"`
+
+---
+
+## 1. Winget
+
+Package manager app installed via Windows Package Manager (winget).
+
+### app.json
+
+```json
+{
+  "appType": "winget",
+  "appId": "Microsoft.VisualStudioCode",
+  "environments": "Work|Personal",
+  "installArgs": "optional-override-args",
+  "preventUpgrade": false,
+  "configuration": {
+    "registrySettings": [
+      {
+        "keyName": "HKEY_CURRENT_USER\\SOFTWARE\\...",
+        "valueName": "SomeSetting",
+        "valueData": "SomeValue"
+      }
+    ]
+  }
+}
+```
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `installArgs` | string | `""` | If provided, prepended with ` --override `. If null/whitespace, empty string. |
+| `preventUpgrade` | bool | `false` | If true, skip upgrade even when already installed |
+| `configuration` | object | null | Registry settings to apply after install |
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `winget install --id {AppId} --accept-package-agreements -h -e{InstallArgs}` |
+| Verify | `(winget list --id {AppId} -e \| Select-String {AppId}) -ne $null` |
+| Upgrade | `winget upgrade --id {AppId} --accept-package-agreements -h -e{InstallArgs}` |
+
+### InstallArgs Behavior
+
+The `InstallArgs` setter transforms the value:
+- If null/whitespace: stored as `""` (empty)
+- Otherwise: stored as `" --override {value}"`
+
+This means the raw app.json value `"install-args"` becomes `" --override install-args"` in the script.
+
+---
+
+## 2. Scoop
+
+Package installed via the Scoop package manager.
+
+### app.json
+
+```json
+{
+  "appType": "scoop",
+  "appId": "7zip",
+  "environments": "Personal",
+  "installArgs": "optional-extra-args",
+  "preventUpgrade": false,
+  "configuration": null
+}
+```
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `installArgs` | string | `""` | Extra args, prepended with a space if provided |
+| `preventUpgrade` | bool | `false` | If true, skip upgrade |
+| `configuration` | object | null | Registry settings |
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `scoop install {AppId}{InstallArgs}` |
+| Verify | `(scoop export \| Select-String {AppId}) -ne $null` |
+| Upgrade | `scoop update {AppId}` |
+
+### InstallArgs Behavior
+
+- If null/whitespace: stored as `""` (empty)
+- Otherwise: stored as `" {value}"`
+
+---
+
+## 3. ScoopBucket
+
+Adds a Scoop bucket (repository of package definitions).
+
+### app.json
+
+```json
+{
+  "appType": "scoopBucket",
+  "appId": "extras",
+  "environments": "Personal"
+}
+```
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| PreventUpgrade | false |
+| UpgradeScript | null |
+| Configuration | null |
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `scoop bucket add {AppId}` |
+| Verify | `(scoop bucket list \| Select-String {AppId}) -ne $null` |
+| Upgrade | null (not upgradeable) |
+
+### BUG NOTE
+
+The C# verification script has a bug: `{AppId}` is inside a verbatim string literal and is NOT interpolated. The PowerShell version should fix this to properly include the app ID.
+
+---
+
+## 4. PowerShell
+
+App installed via external PowerShell script files located in the app's manifest directory.
+
+### app.json
+
+```json
+{
+  "appType": "powerShell",
+  "appId": "my-custom-app",
+  "environments": "Work"
+}
+```
+
+### Script Resolution
+
+The PowerShell app type does NOT define scripts inline in app.json. Instead, scripts are loaded from files in the app directory:
+
+| Script | File | Requirement |
+|--------|------|-------------|
+| Install | `<manifest>/apps/<appId>/install.ps1` | **Required** - app is dropped if missing |
+| Upgrade | `<manifest>/apps/<appId>/upgrade.ps1` | Optional - null if missing |
+| Verify | `<manifest>/apps/<appId>/verification.ps1` | Optional - null if missing |
+
+### Script Format
+
+Scripts are dot-sourced:
+- Install: `. "<manifest>/apps/<appId>/install.ps1"`
+- Upgrade: `. "<manifest>/apps/<appId>/upgrade.ps1"`
+- Verification: `. "<manifest>/apps/<appId>/verification.ps1"`
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| Shell | PowerShell |
+| InstallArgs | null |
+| PreventUpgrade | false |
+| Configuration | null |
+
+### Special Behaviors
+
+- If `install.ps1` does not exist: the entire app is silently dropped from the manifest (returns null from parser)
+- If `upgrade.ps1` or `verification.ps1` don't exist: the corresponding script property is null
+- The `Shell` property is set to `Shell.PowerShell` which triggers the file-based script loading path
+
+---
+
+## 5. PowerShellModule
+
+PowerShell module installed via `Install-Module` / `Update-Module`.
+
+### app.json
+
+```json
+{
+  "appType": "powerShellModule",
+  "appId": "posh-git",
+  "environments": "Work",
+  "installArgs": "-Force -AllowClobber",
+  "preventUpgrade": false,
+  "configuration": null
+}
+```
+
+### Optional Fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `installArgs` | string | `""` | Extra args, prepended with space |
+| `preventUpgrade` | bool | `false` | If true, skip upgrade |
+| `configuration` | object | null | Registry settings |
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `Import-Module PowerShellGet -UseWindowsPowerShell\nInstall-Module -Name {AppId}{InstallArgs}` |
+| Verify | `(Get-Module -ListAvailable {AppId}) -ne $null` |
+| Upgrade | `Import-Module PowerShellGet -UseWindowsPowerShell\nUpdate-Module -Name {AppId}{InstallArgs}` |
+
+Note: Install and Upgrade scripts are multi-line (contain `\n`).
+
+### InstallArgs Behavior
+
+Same as Scoop: prepended with space if non-empty.
+
+---
+
+## 6. PowerShellAppPackage
+
+App package (MSIX/Appx) installed via `Add-AppPackage` after downloading.
+
+### app.json
+
+```json
+{
+  "appType": "powerShellAppPackage",
+  "appId": "Microsoft.DesktopAppInstaller",
+  "environments": "Work",
+  "preventUpgrade": false,
+  "downloader": "GitHubAssetDownloader",
+  "downloaderArgs": {
+    "User": "microsoft",
+    "Repo": "winget-cli",
+    "Extension": ".msixbundle"
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `preventUpgrade` | bool | No | false | Prevent upgrade |
+| `downloader` | string | Yes | - | Name of the downloader class |
+| `downloaderArgs` | object | Yes | - | JSON passed to the downloader |
+
+### Implements IDownloadApp
+
+This type goes through `DownloadAppInstaller` which downloads the file first, then installs.
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `Import-Module appx -UseWindowsPowerShell\nAdd-AppPackage {DownloadedFilePath}` |
+| Verify | `Import-Module appx -UseWindowsPowerShell\n(Get-AppPackage -Name {AppId}) -ne $null` |
+| Upgrade | Same as Install |
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| Configuration | null |
+
+---
+
+## 7. Script
+
+Generic app with inline install/verify/upgrade scripts defined directly in app.json.
+
+### app.json
+
+```json
+{
+  "appType": "script",
+  "appId": "my-custom-setup",
+  "environments": "Work",
+  "installScript": "iwr get.scoop.sh -OutFile $env:tmp\\install.ps1; & $env:tmp\\install.ps1",
+  "verificationScript": "(Get-Command scoop -ErrorAction SilentlyContinue) -ne $null",
+  "upgradeScript": null,
+  "configuration": {
+    "registrySettings": []
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `installScript` | string | Yes | - | PowerShell script to install |
+| `verificationScript` | string | No | null | Script that returns bool |
+| `upgradeScript` | string | No | null | Script to upgrade |
+| `configuration` | object | No | null | Registry settings |
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| PreventUpgrade | false |
+
+---
+
+## 8. GitRepo
+
+Clones a git repository to a specified directory.
+
+### app.json
+
+```json
+{
+  "appType": "gitRepo",
+  "appId": "git.my-project",
+  "environments": "Work",
+  "installArgs": "https://github.com/org/repo.git",
+  "preventUpgrade": true
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `installArgs` | string | Yes* | Git clone URL. If null/whitespace, app is dropped |
+| `preventUpgrade` | bool | No | Default false |
+
+*If `installArgs` is null or whitespace, `ParseGitRepoApp` returns null and the app is silently excluded from the manifest.
+
+### Runtime Properties
+
+The `CloneRootDirectory` is set during manifest loading from `settings.git.cloneDirectory`. It ensures a trailing backslash.
+
+The `RepoName` is derived from `InstallArgs`: strips `.git`, splits on `\` or `/`, takes the last segment.
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `mkdir {CloneRootDirectory} -Force;pushd {CloneRootDirectory};git clone {InstallArgs};popd` |
+| Verify | `Test-Path {CloneRootDirectory}{RepoName}` |
+| Upgrade | `pushd {CloneRootDirectory}{RepoName};git pull;popd` |
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| Configuration | null |
+
+---
+
+## 9. Gitconfig
+
+Adds a git include path to the global git configuration.
+
+### app.json
+
+```json
+{
+  "appType": "gitconfig",
+  "appId": "path/to/.gitconfig-custom",
+  "environments": "Work"
+}
+```
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `git config --global --add include.path {AppId}` |
+| Verify | `(git config --get-all --global include.path) -match "{AppId}"` |
+| Upgrade | null (not upgradeable) |
+
+Note: In the verification script, backslashes in the AppId are escaped (doubled) for the regex match.
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| PreventUpgrade | false |
+| UpgradeScript | null |
+| Configuration | null |
+
+---
+
+## 10. NonPackageApp
+
+App that uses a convention-based install script. No verification or upgrade.
+
+### app.json
+
+```json
+{
+  "appType": "nonPackageApp",
+  "appId": "my-custom-thing",
+  "environments": "Work"
+}
+```
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | `./{AppId}_install.ps1` |
+| Verify | null |
+| Upgrade | null |
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| PreventUpgrade | false |
+| Configuration | null |
+
+### Note
+
+The install script path is relative (`./{AppId}_install.ps1`), meaning it depends on the current working directory at execution time. This is fragile and may not work as expected.
+
+---
+
+## 11. VisualStudioExtension
+
+Visual Studio extension installed via VSIX installer, downloaded from the Visual Studio Marketplace.
+
+### app.json
+
+```json
+{
+  "appType": "visualStudioExtension",
+  "appId": "visual-studio-extension-app-id",
+  "environments": "Work",
+  "preventUpgrade": false,
+  "downloaderArgs": {
+    "Publisher": "Shanewho",
+    "ExtensionName": "IHateRegions"
+  }
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `preventUpgrade` | bool | No | Default false |
+| `downloaderArgs` | object | Yes | Publisher and ExtensionName |
+
+### Implements IDownloadApp
+
+The `Downloader` property is hardcoded to `"VisualStudioMarketplaceDownloader"`.
+
+### Generated Scripts
+
+| Script | Template |
+|--------|----------|
+| Install | See below |
+| Verify | null |
+| Upgrade | Same as Install |
+
+**Install Script:**
+```powershell
+$vsixInstaller = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property productPath | Split-Path | % { "$_\VSIXInstaller.exe" }
+$installArgs = "/quiet", "/admin", "{DownloadedFilePath}"
+Start-Process $vsixInstaller $installArgs -Wait
+```
+
+### BUG NOTE
+
+The C# source has a typo: `$vsi0xInstaller` (zero instead of 'x') in the `Start-Process` call. The PowerShell version should fix this.
+
+### Fixed Properties
+
+| Property | Value |
+|----------|-------|
+| InstallArgs | null |
+| Configuration | null |
+
+---
+
+## 12. GitHubAsset (Internal Only)
+
+Downloads an asset from a GitHub release. Used internally by `SelfInstaller` only. Not exposed as a manifest AppType.
+
+### Class Name
+
+C# class: `GitHubAssestApp` (typo - should be `GitHubAssetApp`)
+
+### Properties
+
+| Property | Value |
+|----------|-------|
+| InstallScript | `string.Empty` (no-op) |
+| VerificationScript | null |
+| UpgradeScript | null |
+| PreventUpgrade | true |
+| Configuration | null |
+| InstallArgs | null |
+| Downloader | `"GitHubAssetDownloader"` |
+
+### Implements IDownloadApp
+
+The only meaningful action is downloading the file. The install script is empty, so the AppInstaller flow will skip the install step. The downloaded file path is set by the DownloadAppInstaller.
+
+### Not Available in Manifests
+
+This type has no corresponding `AppType` enum value. It cannot be used in app.json files. It is created programmatically in `SelfInstaller`.
+
+---
+
+## App Type Summary Matrix
+
+| App Type | InstallArgs | PreventUpgrade | Configuration | Verification | Upgrade | Download |
+|----------|-------------|----------------|---------------|-------------|---------|----------|
+| Winget | `--override {val}` | Settable | Settable | Yes | Yes | No |
+| Scoop | ` {val}` | Settable | Settable | Yes | Yes | No |
+| ScoopBucket | null | false | null | Yes (buggy) | No | No |
+| PowerShell | null | false | null | Optional file | Optional file | No |
+| PowerShellModule | ` {val}` | Settable | Settable | Yes | Yes | No |
+| PowerShellAppPackage | null | Settable | null | Yes | Yes (=install) | Yes |
+| Script | null | false | Settable | Optional field | Optional field | No |
+| GitRepo | Clone URL | Settable | null | Yes | Yes | No |
+| Gitconfig | null | false | null | Yes | No | No |
+| NonPackageApp | null | false | null | No | No | No |
+| VisualStudioExtension | null | Settable | null | No | Yes (=install) | Yes |
+| GitHubAsset (internal) | null | true | null | No | No | Yes |

--- a/configurator-pwsh/spec/SPECIFICATION.md
+++ b/configurator-pwsh/spec/SPECIFICATION.md
@@ -1,0 +1,779 @@
+# Configurator PowerShell Rewrite - Behavior Specification
+
+This document is the authoritative behavioral contract for the PowerShell rewrite of the Configurator tool. It was derived by reading every C# source file in the original codebase. Implementers should be able to build from this spec without referencing the C# code.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [CLI Commands](#cli-commands)
+3. [Settings Management](#settings-management)
+4. [Manifest Loading](#manifest-loading)
+5. [App Installation Flow](#app-installation-flow)
+6. [App Configuration (Registry)](#app-configuration-registry)
+7. [Backup Flow](#backup-flow)
+8. [PowerShell Execution Wrapper](#powershell-execution-wrapper)
+9. [Downloaders](#downloaders)
+10. [System Initialization](#system-initialization)
+11. [Self-Install Mechanism](#self-install-mechanism)
+12. [Privilege/Elevation Checking](#privilegeelevation-checking)
+13. [Tokenizer (Variable Substitution)](#tokenizer-variable-substitution)
+14. [Desktop Shortcut Deletion](#desktop-shortcut-deletion)
+15. [Logging/Console Output](#loggingconsole-output)
+16. [Error Codes](#error-codes)
+17. [Known Bugs and Quirks](#known-bugs-and-quirks)
+
+---
+
+## Overview
+
+Configurator is a Windows machine configuration tool that:
+- Reads a manifest repo containing a list of apps and per-app definitions
+- Installs, upgrades, verifies, and configures each app via PowerShell scripts
+- Supports 12 app types with different installation strategies
+- Manages its own settings (persisted as JSON in LocalAppData)
+- Can initialize a fresh machine by installing prerequisites and cloning the manifest repo
+- Can back up app configurations
+
+The PowerShell rewrite must consume the **exact same manifest format** (manifest.json + apps/{AppId}/app.json).
+
+---
+
+## CLI Commands
+
+The CLI requires elevated privileges (administrator). If not elevated, it prints an error and returns exit code 2.
+
+If no arguments are provided, `--help` is shown (exit code 0).
+
+### `initialize`
+
+**Description:** Runs system initialization prerequisites and clones the manifest repo.
+
+**Parameters:** None
+
+**Behavior:**
+1. Run `SystemInitializer.InitializeAsync()` (see [System Initialization](#system-initialization))
+2. Load settings, read `manifest.repo` setting
+3. If `manifest.repo` is null, throw: `"The 'manifest.repo' setting must be set before invoking initialize."`
+4. Compute manifest directory: `Path.Combine(git.clonedirectory, repoNameFromUrl)`
+   - Repo name extracted from URL: last segment, with `.git` stripped
+5. If `manifest.directory` in settings differs from computed value, update settings and save
+6. If manifest directory does not exist on disk, clone the repo:
+   ```powershell
+   Push-Location <git.clonedirectory>
+   git clone <manifest.repo>
+   Pop-Location
+   ```
+7. If the manifest file (`manifest.json` by default) does not exist inside the manifest directory:
+   - Write `"{ }"` to the file
+   - Commit and push:
+   ```powershell
+   Push-Location <manifest.directory>
+   git add .
+   git commit -m '[Configurator] Create manifest file'
+   git push
+   Pop-Location
+   ```
+8. If everything already exists, do nothing (idempotent).
+
+### `configure-machine` (alias: `configure`)
+
+**Description:** Install/upgrade apps from the manifest.
+
+**Parameters:**
+- `--environments` / `-e` (optional): Pipe-separated list of environment names. Parsed by splitting on `|`. Example: `--environments "Work|Personal"`
+- `--single-app-id` / `-app` (optional): A single app ID to install. When present, environments are ignored.
+
+**Behavior:**
+- If `--single-app-id` is provided:
+  1. Load the full manifest (all environments, no filtering)
+  2. Find the app matching the ID (first match)
+  3. Run install/upgrade + configure for that single app
+- Otherwise:
+  1. Load the manifest filtered by the specified environments
+  2. For each app in order:
+     - If the app implements `IDownloadApp`, use `DownloadAppInstaller`
+     - Otherwise use `AppInstaller`
+     - Then run `AppConfigurator.Configure(app)`
+
+### `settings list`
+
+**Description:** Display all settings as a table.
+
+**Parameters:** None
+
+**Behavior:**
+1. Load settings from disk
+2. Use reflection to walk the `Settings` object tree
+3. For each leaf property (primitive, Uri, or string), collect: Name (dotted path, lowercased), Value (`.ToString()`), Type (type name)
+4. Node properties (ManifestSettings, GitSettings) are recursed into with the dotted prefix
+5. Output as a table (Name, Value, Type columns)
+
+**Expected settings paths:**
+- `downloadsdirectory` (Uri, default: `C:/tmp/configurator-downloads`)
+- `manifest.repo` (Uri, default: null)
+- `manifest.filename` (String, default: `manifest.json`)
+- `manifest.directory` (String, default: null)
+- `git.clonedirectory` (Uri, default: `C:\src\`)
+
+### `settings set <setting-name> <setting-value>`
+
+**Description:** Update a single setting by its dotted path name.
+
+**Parameters:**
+- `setting-name` (positional argument): The dotted path (e.g., `manifest.repo`)
+- `setting-value` (positional argument): The new value
+
+**Behavior:**
+1. Load settings
+2. Walk the settings tree to find the leaf property matching the dotted path (case-insensitive match via `.ToLower()`)
+3. If not found, throw `ArgumentException`: `"{settingName} is not a recognized setting name."`
+4. Convert the string value to the target type:
+   - `Uri` type: `new Uri(settingValue)`
+   - All others: use string directly
+5. Set the property value via reflection
+6. Save settings
+
+### `add-app` (alias: `add`)
+
+**Description:** Add a new app definition to the manifest.
+
+**Parameters:**
+- `--app-id` (string): The app identifier
+- `--app-type` (AppType enum): The installer type
+- `--environments` (string): Pipe-separated environment list
+
+**Behavior:**
+1. Create an `Installable` with the provided values (environments joined with `|`)
+2. Call `ManifestRepository.SaveInstallableAsync`:
+   - Load the manifest file
+   - If the app ID already exists in the manifest's Apps list, return without changes (idempotent)
+   - Create the app directory: `<manifest.directory>/apps/<appId>/`
+   - Write the app.json file (human-readable JSON, indented)
+   - Add the app ID to the manifest's Apps list
+   - Write the updated manifest file
+
+### `backup`
+
+**Description:** Run backup scripts for all apps in the manifest.
+
+**Parameters:** None
+
+**Behavior:**
+1. Load the full manifest (no environment filtering, empty list passed)
+2. For each app in the manifest, call `AppConfigurator.Backup(app)`:
+   - Check if the app has a non-empty verification script
+   - If it does, run the verification script. If the result is `false` (app not installed), skip.
+   - If the app is installed, look for `<manifest.directory>/apps/<appId>/backup.ps1`
+   - If the file exists, log `"Backing up {appId}..."`, execute it, log `"Backed up {appId}!"`
+   - If the file does not exist or the app is not installed, skip silently.
+
+---
+
+## Settings Management
+
+### Settings Object Structure
+
+```json
+{
+  "downloadsDirectory": "C:/tmp/configurator-downloads",
+  "manifest": {
+    "repo": null,
+    "fileName": "manifest.json",
+    "directory": null
+  },
+  "git": {
+    "cloneDirectory": "C:\\src\\"
+  }
+}
+```
+
+**Default values:**
+- `downloadsDirectory`: `C:/tmp/configurator-downloads` (Uri)
+- `manifest.repo`: null (Uri, nullable)
+- `manifest.fileName`: `manifest.json` (string)
+- `manifest.directory`: null (string, nullable - set during initialize)
+- `git.cloneDirectory`: `C:\src\` (Uri)
+
+### Persistence Path
+
+Settings are stored at:
+```
+<LocalAppData>/Configurator/settings.json
+```
+
+Where `<LocalAppData>` is `Environment.SpecialFolder.LocalApplicationData` (typically `C:\Users\<user>\AppData\Local`).
+
+### Load Behavior
+
+1. Compute the settings file path: `<LocalAppData>/Configurator/settings.json`
+2. If the file does not exist:
+   - Create the directory `<LocalAppData>/Configurator/`
+   - Write default (empty) settings to the file
+3. Ensure the downloads directory exists (create if missing)
+4. Read and deserialize the settings file
+5. Return the Settings object
+
+### Save Behavior
+
+1. Serialize settings to JSON
+2. Write to the settings file path
+3. Ensure the downloads directory exists
+
+### JSON Serialization
+
+Two serializers are used:
+- **JsonSerializer** (for settings): camelCase property naming, case-insensitive read, enum as camelCase string
+- **HumanReadableJsonSerializer** (for manifest/app files): same as above plus `WriteIndented = true`
+
+Both use `System.Text.Json` with:
+- `PropertyNameCaseInsensitive = true`
+- `PropertyNamingPolicy = JsonNamingPolicy.CamelCase`
+- `JsonStringEnumConverter(JsonNamingPolicy.CamelCase)` for enum handling
+
+---
+
+## Manifest Loading
+
+### manifest.json Format
+
+```json
+{
+  "apps": [
+    "app-id-1",
+    "app-id-2",
+    "app-id-3"
+  ]
+}
+```
+
+The manifest file also supports a `todo` array (seen in the real machine-configs repo) which is ignored by the tool.
+
+### App Directory Structure
+
+```
+<manifest.directory>/
+  manifest.json
+  apps/
+    <app-id>/
+      app.json
+      install.ps1     (optional, for PowerShell app type)
+      upgrade.ps1     (optional, for PowerShell app type)
+      verification.ps1 (optional, for PowerShell app type)
+      backup.ps1      (optional, for backup command)
+```
+
+### app.json Common Fields
+
+Every app.json must have:
+```json
+{
+  "appType": "<AppType>",
+  "appId": "<string>",
+  "environments": "<pipe-separated-string>"
+}
+```
+
+### Loading Process
+
+1. Load settings to get `manifest.directory` and `manifest.fileName`
+2. Read `<manifest.directory>/<manifest.fileName>` to get the list of app IDs
+3. If the manifest file doesn't exist, create it with `{}` content
+4. For each app ID, read `<manifest.directory>/apps/<appId>/app.json`
+5. Parse the raw JSON to get `AppType`, `AppId`, and `Environments`
+6. Filter by specified environments:
+   - If no environments specified, include all apps
+   - Otherwise, check if any specified environment appears in the app's `Environments` string (case-insensitive `Contains` check)
+   - Environment comparison: the app's `Environments` string is lowered, each specified environment is lowered, then `Contains` is used (substring match, not exact word match)
+7. Parse each app into its typed object using `AppType` as the discriminator
+8. Return `Manifest { AppIds, Apps }`
+
+### Loading a Single App
+
+When loading a single app by ID (for `--single-app-id`):
+1. Load the full manifest with no environment filtering
+2. Find the first app where `AppId` matches
+3. Return that app
+
+### Unknown App Types
+
+Apps with `AppType = Unknown` or any unrecognized type are parsed as `null` and filtered out. They are silently skipped.
+
+### Environment Filtering Details
+
+The `Environments` field in app.json is a pipe-separated string (e.g., `"Environment1|Environment3"`). The filtering uses case-insensitive string `Contains`, not exact word matching. This means an environment filter of `"Env"` would match `"Environment1"`.
+
+---
+
+## App Installation Flow
+
+### AppInstaller.InstallOrUpgradeAsync
+
+This is the core installation logic for all app types.
+
+**Flow:**
+1. Log: `"Installing '{appId}'"`
+2. Snapshot desktop entries (pre-install)
+3. Run verification script (if exists):
+   - If `VerificationScript` is null, verification returns `false` (treat as not installed)
+   - Otherwise, execute the script and parse result as bool
+4. Determine action:
+   - If NOT verified (not installed): use `InstallScript`
+   - If verified AND `UpgradeScript` is not null AND `PreventUpgrade` is false: use `UpgradeScript`
+   - Otherwise: no action (empty string, which is skipped via `IsNullOrWhiteSpace` check)
+5. Execute the action script (if non-empty)
+6. After execution, run verification again (post-install check)
+7. If post-install verification fails: log debug `"Failed to install '{appId}'"`
+8. Snapshot desktop entries (post-install)
+9. Delete any new desktop entries added during install
+10. Log: `"Installed '{appId}'"`
+
+### ForceWindowsPowerShell Variant
+
+PowerShell Core (pwsh.exe) is the default for all script execution. But during initialization, PowerShell Core may not yet be installed. The `IAppInstallerForceWindowsPowerShell` interface uses `ExecuteWindowsAsync` (powershell.exe) instead of `ExecuteAsync` (pwsh.exe) for all operations.
+
+This is used specifically by `PowerShellCoreInstaller` to install PS Core using Windows PowerShell.
+
+### DownloadAppInstaller
+
+For apps implementing `IDownloadApp` (PowerShellAppPackage, VisualStudioExtensionApp, GitHubAssetApp):
+
+1. Log: `"Downloading '{appId}'"`
+2. Get the downloader by name from the factory
+3. Call `downloader.DownloadAsync(downloaderArgs.ToString())`
+4. Set `app.DownloadedFilePath` to the returned path
+5. Log: `"Downloaded '{appId}'"`
+6. Delegate to `AppInstaller.InstallOrUpgradeAsync(app)` for the actual install
+
+---
+
+## App Configuration (Registry)
+
+After installation, `AppConfigurator.Configure(app)` is called:
+
+1. If `app.Configuration` is null, return immediately
+2. For each `RegistrySetting` in `Configuration.RegistrySettings`:
+   - Call `RegistryRepository.SetValue(keyName, valueName, valueData)`
+
+### Registry Value Types
+
+The `ValueData` field in a RegistrySetting supports:
+- **String**: stored as `RegistryValueKind.String`
+- **UInt32** (number in JSON): stored as `RegistryValueKind.DWord`
+
+The `RegistrySettingValueDataConverter` custom JSON converter:
+- JSON string -> detokenize via Tokenizer, return string
+- JSON number -> `reader.GetUInt32()`, return uint
+- Other types -> throw exception
+
+### Registry Operations
+
+**SetValue:**
+- Determines `RegistryValueKind` from the .NET type of the value
+- For `uint`: converts to `int` (unchecked cast) before writing via `Registry.SetValue`
+- Logs errors with full key/value details on failure, then rethrows
+
+**GetValue:**
+- Reads via `Registry.GetValue`
+- If result is `int`: convert to `uint` via BitConverter
+- If result is `long`: convert to `ulong` via BitConverter
+- Returns `.ToString()`
+
+**GetSubKeyNames:**
+- Opens the key under `HKEY_LOCAL_MACHINE` via `Registry.LocalMachine.OpenSubKey`
+- Returns sub-key names, or empty array if key doesn't exist
+
+---
+
+## Backup Flow
+
+`AppConfigurator.Backup(app)`:
+
+1. Check if the app has a non-empty `VerificationScript`
+2. If it does, execute it to check if the app is installed
+3. If `VerificationScript` is null/empty OR execution returns false -> skip (return early)
+4. Load settings to get manifest directory
+5. Construct backup script path: `<manifest.directory>/apps/<appId>/backup.ps1`
+6. If the file exists:
+   - Log: `"Backing up {appId}..."`
+   - Execute the backup script via PowerShell
+   - Log: `"Backed up {appId}!"`
+7. If the file doesn't exist, do nothing
+
+---
+
+## PowerShell Execution Wrapper
+
+All script execution goes through the `PowerShell` class which wraps process execution.
+
+### Execution Modes
+
+| Method | Executable | Use Case |
+|--------|-----------|----------|
+| `ExecuteAsync(script)` | pwsh.exe | Normal execution via PS Core |
+| `ExecuteAdminAsync(script)` | pwsh.exe | Elevated execution via PS Core |
+| `ExecuteAsync<T>(script)` | pwsh.exe | Execute and parse last output line |
+| `ExecuteWindowsAsync(script)` | powershell.exe | Windows PowerShell execution |
+| `ExecuteWindowsAdminAsync(script)` | powershell.exe | Elevated Windows PowerShell |
+| `ExecuteWindowsAsync<T>(script)` | powershell.exe | Windows PS with result |
+
+### Environment-Ready Script Wrapping
+
+Every script is wrapped with environment setup before execution:
+
+```powershell
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+if ($profile -eq $null -or $profile -eq '') {
+  $global:profile = "<MyDocuments>/<PSFolderName>/Microsoft.PowerShell_profile.ps1"
+}
+
+<actual script>
+```
+
+Where `<PSFolderName>` is:
+- `"PowerShell"` for PS Core (pwsh.exe)
+- `"WindowsPowerShell"` for Windows PowerShell (powershell.exe)
+
+This ensures:
+1. PATH is rebuilt from Machine + User environment variables (not inherited from parent process)
+2. `$profile` is set correctly if not already defined
+
+### Script-to-File Conversion
+
+Scripts are not passed inline. They are:
+1. Written to a temp file at `<LocalAppData>/Configurator/temp/<timestamp>.ps1`
+2. Timestamp format: `yyyy-MM-dd_HH-mm-ss-fffff`
+3. Executed via `-File <path>`
+
+### pwsh.exe Discovery
+
+PS Core's install location is found via the Windows Registry:
+1. Read sub-keys of `SOFTWARE\Microsoft\PowerShellCore\InstalledVersions`
+2. Take the first sub-key (GUID)
+3. Read `InstallLocation` value from `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\PowerShellCore\InstalledVersions\{GUID}`
+4. Executable path: `{InstallLocation}pwsh.exe`
+
+If no installed versions are found, throw: `"PowerShell Core is not installed. No versions found in registry."`
+
+### Process Execution
+
+The `ProcessRunner` launches processes with:
+- `UseShellExecute = RunAsAdmin` (true for admin, false for normal)
+- `RedirectStandardOutput = !RunAsAdmin`
+- `RedirectStandardError = !RunAsAdmin`
+- `Verb = RunAsAdmin ? "runas" : "open"`
+- `FileName = <executable>`
+- `Arguments = -File <scriptFilePath>`
+
+For admin execution: output/error cannot be captured (shell execute mode).
+
+**Output handling:**
+- Each stdout line is added to `AllOutput` and logged via `Debug`
+- `LastOutput` tracks the most recent output line
+- Each stderr line is cleaned of ANSI escape sequences and added to `Errors`, logged via `Debug`
+
+**Error handling:**
+- All error strings are logged via `consoleLogger.Error`
+- If exit code != 0, throw: `"Script failed to complete with exit code {exitCode}"`
+
+### Result Type Mapping
+
+When a typed result is expected (`ExecuteAsync<T>`):
+- `string`: return `LastOutput` as-is
+- `bool`: parse `LastOutput` via `bool.Parse()` (supports True/False, case-insensitive)
+- Other types: throw `NotSupportedException`
+- If `LastOutput` is null: return `default(T)`
+
+---
+
+## Downloaders
+
+### DownloaderFactory
+
+Resolves downloader by name using reflection:
+1. Construct type name: `Configurator.Downloaders.{downloaderName}`
+2. Resolve type via `Type.GetType`
+3. If type not found, throw with message containing the name and namespace
+4. Resolve instance from DI container
+
+### GitHubAssetDownloader
+
+**DownloaderArgs format:**
+```json
+{
+  "User": "dannydwarren",
+  "Repo": "configurator",
+  "Extension": ".exe"
+}
+```
+
+**Flow:**
+1. Deserialize args JSON
+2. Execute PowerShell script to query GitHub API:
+   ```powershell
+   $asset = (iwr https://api.github.com/repos/{User}/{Repo}/releases/latest | ConvertFrom-Json).assets | ? { $_.name -like '*{Extension}' }
+   $downloadUrl = $asset | select -exp browser_download_url
+   $fileName = $asset | select -exp name
+   Write-Output "{ `"FileName`": `"$fileName`", `"Url`": `"$downloadUrl`" }"
+   ```
+3. Parse the JSON output to get `FileName` and `Url`
+4. Download the file via `ResourceDownloader`
+5. Return the local file path
+
+### VisualStudioMarketplaceDownloader
+
+**DownloaderArgs format:**
+```json
+{
+  "Publisher": "Shanewho",
+  "ExtensionName": "IHateRegions"
+}
+```
+
+**Flow:**
+1. Deserialize args JSON
+2. HTTP GET the extension page: `https://marketplace.visualstudio.com/items?itemName={Publisher}.{ExtensionName}`
+3. Regex-match the versioned download URL from the page HTML:
+   ```
+   /_apis/public/gallery/publishers/{Publisher}/vsextensions/{ExtensionName}/(\d+\.?)+/vspackage
+   ```
+4. Build full download URL: `https://marketplace.visualstudio.com{matchedPath}`
+5. Download file as `{Publisher}.{ExtensionName}.vsix`
+6. Return the local file path
+
+### ResourceDownloader
+
+Downloads a file from a URL:
+1. HTTP GET the URL
+2. If status code != 200, throw: `"Failed with status code {code} to download {fileName}"`
+3. Write the stream to `<downloadsDirectory>/{fileName}`
+4. Return the full file path
+
+---
+
+## System Initialization
+
+`SystemInitializer.InitializeAsync()` runs these steps **in order**:
+
+1. **Set Windows PowerShell Execution Policy**
+   - Execute `Set-ExecutionPolicy RemoteSigned -Force` via Windows PowerShell (admin)
+   - Report the policy result via `Get-ExecutionPolicy`
+   - Report the version via `$PSVersionTable.PSVersion.ToString()`
+
+2. **Upgrade Winget**
+   - Execute via Windows PowerShell:
+     ```powershell
+     Add-AppxPackage https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -ForceTargetApplicationShutdown
+     ```
+     ```powershell
+     Add-AppxPackage https://cdn.winget.microsoft.com/cache/source.msix
+     ```
+
+3. **Accept Winget Source Agreements**
+   - Execute via Windows PowerShell:
+     ```powershell
+     winget list winget --accept-source-agreements
+     ```
+
+4. **Install PowerShell Core**
+   - Install `Microsoft.PowerShell` via Winget using **Windows PowerShell** (ForceWindowsPowerShell)
+   - This uses the `AppInstaller` flow with `WingetApp { AppId = "Microsoft.PowerShell" }`
+
+5. **Set PowerShell Core Execution Policy**
+   - Execute `Set-ExecutionPolicy RemoteSigned -Force` via PS Core (admin)
+   - Report policy and version via PS Core
+
+6. **Self-Install** (see [Self-Install Mechanism](#self-install-mechanism))
+
+7. **Install Scoop CLI**
+   - Uses `ScriptApp` with:
+     - Install: `iwr get.scoop.sh -OutFile $env:tmp\scoop-install.ps1` then `& $env:tmp\scoop-install.ps1 -RunAsAdmin`
+     - Verification: test if `scoop` command exists via `Get-Command`
+
+8. **Install Git**
+   - Install `Git.Git` via Winget (via normal `AppInstaller`)
+
+9. **Install Manifest Repo**
+   - Load settings to get `manifest.repo` URL
+   - If `manifest.repo` is null, throw `ArgumentException: "Missing setting: Manifest.Repo"`
+   - Install as `GitRepoApp { AppId = "git.manifest-repo", InstallArgs = repoUrl, CloneRootDirectory = git.cloneDirectory }`
+
+---
+
+## Self-Install Mechanism
+
+`SelfInstaller.InstallAsync()`:
+
+1. Check if `c:\Configurator` directory exists
+2. If it exists, return immediately (already installed)
+3. Set up a `GitHubAssetApp` with:
+   - AppId: `"Configurator"`
+   - DownloaderArgs: `{ "User": "dannydwarren", "Repo": "configurator", "Extension": ".exe" }`
+4. Download and install via `DownloadAppInstaller`
+5. Create `c:\Configurator` directory
+6. Move the downloaded file to `c:\Configurator\Configurator.exe`
+7. Add `c:\Configurator` to the machine PATH environment variable
+
+**NOTE for PowerShell rewrite:** This mechanism downloads the C# executable from GitHub releases. For the PowerShell version, this needs to be reimagined - likely downloading/installing the PowerShell module instead.
+
+---
+
+## Privilege/Elevation Checking
+
+Before any CLI command executes:
+1. Check if the current user is running as Administrator
+2. Uses `WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator)`
+3. If not elevated:
+   - Log error: `"Configurator Cli must be run with elevated privileges."`
+   - Return exit code `2` (`ErrorCode.NotEnoughPrivileges`)
+
+---
+
+## Tokenizer (Variable Substitution)
+
+The Tokenizer replaces `{{source:name}}` patterns in strings with actual values.
+
+### Token Pattern
+
+```
+{{source:name}}
+```
+
+- Matched via regex: `(\{\{(.*?)\}\})+`
+- Source and name extracted by trimming `{` and `}`, splitting on `:`
+
+### Supported Sources
+
+| Source | Resolution |
+|--------|-----------|
+| `env` | `Environment.GetEnvironmentVariable(name)` (empty string if null) |
+
+### Usage
+
+Used exclusively in `RegistrySetting.ValueData` deserialization. When a registry setting's ValueData is a string, the Tokenizer replaces any tokens before the value is stored.
+
+**Example:**
+```json
+{
+  "KeyName": "key-2",
+  "ValueName": "string",
+  "ValueData": "{{env:ProgramFiles}}\\string-data"
+}
+```
+Resolves to: `"C:\Program Files\string-data"`
+
+---
+
+## Desktop Shortcut Deletion
+
+During app installation, desktop shortcuts are automatically cleaned up:
+
+1. Before install: enumerate all files/directories on the user's desktop and common desktop
+2. After install: enumerate again
+3. Compute the difference (new entries)
+4. Delete all new entries
+
+### Desktop Paths
+
+Two desktop locations are checked:
+- User desktop: `Environment.SpecialFolder.Desktop`
+- Common (public) desktop: `Environment.SpecialFolder.CommonDesktopDirectory`
+
+Both paths are enumerated for file system entries. Entries are deduplicated.
+
+### Deletion
+
+- If the path is a file, delete it
+- If the path is a directory, delete it (non-recursive in C# implementation)
+
+---
+
+## Logging/Console Output
+
+### Log Format
+
+```
+[<ISO8601 timestamp>] [<LEVEL>] <message>
+```
+
+Timestamp uses the `O` format specifier (e.g., `2024-01-15T10:30:45.1234567-07:00`).
+
+### Log Levels and Colors
+
+| Level | Label | Color |
+|-------|-------|-------|
+| Debug | `DEBUG` | Gray |
+| Verbose | `INFOV` | White (default) |
+| Info | `INFO ` | White (default) |
+| Warn | `WARN ` | Yellow |
+| Error | `ERROR` | Red |
+| Progress | `PRGRS` | Blue |
+| Result | `RESLT` | Green |
+
+### Table Output
+
+The `settings list` command outputs a table using the `ConsoleTables` library with `Format.Minimal` style. In PowerShell this can be replicated with `Format-Table`.
+
+---
+
+## Error Codes
+
+| Code | Name | Description |
+|------|------|-------------|
+| 0 | Success | (implicit) |
+| 1 | GenericFailure | Invalid CLI arguments or general failure |
+| 2 | NotEnoughPrivileges | CLI not run as administrator |
+
+---
+
+## Known Bugs and Quirks
+
+### GitHubAssestApp Typo
+
+The C# class is named `GitHubAssestApp` (misspelled "Asset"). The PowerShell version should fix this to `GitHubAssetApp`. However, the `AppType` enum does NOT include a `GitHubAsset` entry. The `GitHubAssestApp` is used directly in `SelfInstaller` but is never parsed from manifests via `AppType`. It is created programmatically only.
+
+**Recommendation:** In the PowerShell version, use `GitHubAssetApp` (corrected spelling) but keep it as an internal type not exposed via manifest AppType.
+
+### ScoopBucketApp VerificationScript Bug
+
+The C# `ScoopBucketApp.VerificationScript` has a bug:
+```csharp
+public string VerificationScript => @"(scoop bucket list | Select-String {AppId}) -ne $null";
+```
+The `{AppId}` is NOT interpolated as a C# string interpolation - it's a verbatim string. This means the literal text `{AppId}` is sent to PowerShell, which would be interpreted as a PowerShell scriptblock, not the actual app ID. This is a bug in the C# version.
+
+**Recommendation:** Fix this in the PowerShell version to properly interpolate the app ID.
+
+### VisualStudioExtensionApp InstallScript Typo
+
+The install script contains `$vsi0xInstaller` (with a zero instead of lowercase 'x'):
+```csharp
+Start-Process $vsi0xInstaller $installArgs -Wait
+```
+The variable is assigned as `$vsixInstaller` but referenced as `$vsi0xInstaller`. This would cause a runtime error.
+
+**Recommendation:** Fix to `$vsixInstaller` in the PowerShell version.
+
+### NonPackageApp InstallScript Convention
+
+The `NonPackageApp` generates its install script as `./{appId}_install.ps1`. This is a relative path, meaning it depends on the current working directory at execution time. The behavior is fragile.
+
+### GitRepoApp Null Return
+
+When `GitRepoApp.InstallArgs` is null or whitespace, `ParseGitRepoApp` returns `null`. These null apps are filtered out by the `.Where(x => x != null)` in manifest loading. This means Git repo apps without InstallArgs are silently dropped.
+
+### PowerShellApp with Missing install.ps1
+
+If a PowerShell app's `install.ps1` file doesn't exist in the app directory, `MapShellAppScripts` returns `default(T)` which is null. These are filtered out during manifest loading. The app is silently dropped.
+
+### Environment Filtering is Substring-Based
+
+The environment filtering uses `Contains` (case-insensitive) rather than exact word matching. An environment filter of `"dev"` would match an app with `Environments = "Development"`.
+
+### Dependency Injection
+
+The C# version uses Scrutor for assembly scanning DI registration (`services.Scan`). All classes are registered as transient, both as themselves and as matching interfaces. A special registration maps `IAppInstallerForceWindowsPowerShell` to `AppInstaller`.
+
+The `RegistrySettingValueDataConverter.Tokenizer` is set via a static property after DI initialization. This is a workaround for the JSON converter not participating in DI.

--- a/configurator-pwsh/spec/TEST_PLAN.md
+++ b/configurator-pwsh/spec/TEST_PLAN.md
@@ -1,0 +1,383 @@
+# Test Plan
+
+This document describes the tests that must exist for the PowerShell Configurator rewrite, derived from the C# unit and integration test suites.
+
+---
+
+## Test Framework
+
+Use **Pester** (PowerShell testing framework) for both unit and integration tests.
+
+For mocking, use Pester's built-in `Mock` capabilities. The C# tests use AutoMoq for auto-mocking dependencies; in PowerShell, we mock at the function/cmdlet level.
+
+---
+
+## Unit Tests
+
+### CLI Tests
+
+**File:** `Cli.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Invalid commandline arg | Returns exit code 1 (GenericFailure) |
+| No elevated privileges | Returns exit code 2, logs error: "Configurator Cli must be run with elevated privileges." |
+| No commandline args | Shows help, returns exit code 0 |
+| `initialize` command | Resolves and executes the initialize command, returns 0 |
+| `settings set <name> <value>` command | Resolves and executes set-setting with both args, returns 0 |
+| `settings list` command | Resolves and executes list-settings, returns 0 |
+| `add-app` with `--app-id`, `--app-type`, `--environments` | Parses pipe-separated environments, executes add-app |
+| `add` (alias) | Same as `add-app` |
+| `configure-machine` | Executes configure with empty environment list and null singleAppId |
+| `configure` (alias) | Same as `configure-machine` |
+| `configure --single-app-id <id>` | Passes the single app ID |
+| `configure -app <id>` | Same as `--single-app-id` |
+| `configure --environments <envs>` | Parses environments |
+| `configure -e <envs>` | Same as `--environments` |
+| `backup` command | Resolves and executes backup command, returns 0 |
+
+### ConfigureMachineCommand Tests
+
+**File:** `ConfigureMachineCommand.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Installing all manifest apps | Loads manifest, installs each app (IDownloadApp via DownloadAppInstaller, others via AppInstaller), configures each |
+| Installing single manifest app | Loads single app by ID, installs and configures it |
+
+### BackupMachineCommand Tests
+
+**File:** `BackupMachineCommand.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Backing up all apps | Loads full manifest (empty environments), calls Backup for each app |
+
+### InitializeCommand Tests
+
+**File:** `InitializeCommand.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| First-time initialization | Calls SystemInitializer, sets manifest directory, clones repo, creates manifest file |
+| With new manifest repo | Creates, commits, and pushes manifest file when it doesn't exist |
+| Already initialized | Does nothing when manifest dir and file already exist |
+| Missing manifest.repo setting | Throws with message: "The 'manifest.repo' setting must be set before invoking initialize." |
+
+### SystemInitializer Tests
+
+**File:** `SystemInitializer.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Full initialization flow | Verifies all 9 steps execute in order: Windows PS exec policy, winget upgrade, winget source agreements, PS Core install, PS Core exec policy, self-install, scoop-cli, git, manifest repo |
+
+### AppInstaller Tests
+
+**File:** `AppInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install (not yet installed) | Runs verification (false), runs install script, runs post-verification, deletes new desktop shortcuts |
+| Force Windows PowerShell | Uses ExecuteWindowsAsync variants instead of ExecuteAsync |
+| No verification script | Skips verification, runs install script directly |
+| Nothing added to desktop | Does not call desktop delete |
+| Upgrade (already installed) | Verification returns true, runs upgrade script, deletes new desktop shortcuts |
+| Prevent upgrade | Verification returns true, PreventUpgrade=true, does NOT run upgrade script |
+| Already installed, no upgrade script | Verification returns true, no upgrade script, does nothing |
+| PowerShell shell app | Same flow but with .ps1 file-based scripts |
+
+### AppConfigurator Tests
+
+**File:** `AppConfigurator.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Configure with registry settings | Sets all provided registry values |
+| No configuration provided | Does nothing |
+| Default configuration (empty registry list) | Does nothing |
+| Backup an installed app | Verifies app is installed, finds and executes backup.ps1, logs |
+| Backup without verification script | Skips (no verification = not verifiable) |
+| Backup not installed app | Verification returns false, skips |
+| Backup without backup script | App is installed but no backup.ps1 exists, skips |
+
+### DownloadAppInstaller Tests
+
+**File:** `DownloadAppInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Download and install | Gets downloader from factory, downloads, sets DownloadedFilePath, delegates to AppInstaller |
+
+### AddAppCommand Tests
+
+**File:** `AddAppCommand.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Add Winget app | Creates Installable with correct AppId, AppType, pipe-joined Environments, saves |
+| Add Scoop app | Same flow, different AppType |
+
+### SelfInstaller Tests
+
+**File:** `SelfInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install | Downloads Configurator from GitHub, moves to c:\Configurator\, adds to machine PATH |
+| Already installed | c:\Configurator exists, does nothing |
+
+### ManifestRepoInstaller Tests
+
+**File:** `ManifestRepoInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install | Creates GitRepoApp with manifest repo URL, installs via AppInstaller |
+| Missing repo setting | Throws ArgumentException with message about missing Manifest.Repo |
+
+### PowerShellCoreInstaller Tests
+
+**File:** `PowerShellCoreInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install | Installs Microsoft.PowerShell WingetApp via ForceWindowsPowerShell |
+
+### ScoopCliInstaller Tests
+
+**File:** `ScoopCliInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install | Installs ScriptApp with scoop install/verification scripts |
+
+### GitInstaller Tests
+
+**File:** `GitInstaller.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Install | Installs Git.Git WingetApp via AppInstaller |
+
+### WingetConfiguration Tests
+
+**File:** `WingetConfiguration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Upgrade | Executes two Add-AppxPackage commands via Windows PowerShell |
+| Accept source agreements | Executes winget list with --accept-source-agreements via Windows PowerShell |
+
+### PowerShellConfiguration Tests
+
+**File:** `PowerShellConfiguration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Set PS Core execution policy | Runs Set-ExecutionPolicy via admin, reports policy and version |
+| Set Windows PS execution policy | Same but via Windows PowerShell |
+
+### PowerShell Execution Tests
+
+**File:** `PowerShellExecution.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Execute Core | Wraps script with env setup, saves to file, executes via pwsh.exe |
+| Execute Windows | Same but with powershell.exe and WindowsPowerShell profile path |
+| Execute as admin (Core) | Uses RunAsAdmin=true, pwsh.exe |
+| Execute as admin (Windows) | Uses RunAsAdmin=true, powershell.exe |
+| Unsuccessful exit code | Throws with message containing exit code |
+| Execute with errors | Logs all errors, throws |
+| Execute with string result | Returns LastOutput as string |
+| Execute with bool result (True/False/true/false/TRUE/FALSE) | Parses bool correctly |
+
+### Settings Tests
+
+**File:** `Settings.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| ListSettingsCommand | Loads settings, maps to table rows with Name/Value/Type, outputs table |
+| SetSettingCommand - manifest.repo | Updates Uri property, saves |
+| SetSettingCommand - manifest.filename | Updates string property, saves |
+| SetSettingCommand - git.clonedirectory | Updates Uri property, saves |
+| SettingsRepository - load existing | Reads and deserializes settings file |
+| SettingsRepository - first load | Creates directory, writes defaults, ensures downloads dir |
+| SettingsRepository - save | Serializes and writes, ensures downloads dir |
+
+### Utility Tests
+
+**File:** `Utilities.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| DesktopRepository - load entries | Enumerates both desktop paths, deduplicates |
+| DesktopRepository - delete paths | Deletes each path |
+| ScriptToFileConverter | Creates temp dir, writes script to timestamped .ps1 file, returns path |
+| Tokenizer - single env token | `{{env:ProgramFiles}}\path` -> `C:\Program Files\path` |
+| Tokenizer - multiple env tokens | Replaces all tokens in string |
+| ResourceDownloader - success | HTTP GET, write stream, return path |
+| ResourceDownloader - failure | Non-200 status throws |
+
+### Downloader Tests
+
+**File:** `Downloaders.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| DownloaderFactory - get by name | Resolves downloader type by name from namespace |
+| DownloaderFactory - unknown name | Throws with message containing name and namespace |
+| GitHubAssetDownloader | Deserializes args, executes PS script to query GitHub API, parses result, downloads |
+| VisualStudioMarketplaceDownloader | Fetches page HTML, regex-matches download URL, downloads |
+
+---
+
+## Integration Tests
+
+### ManifestRepository Integration Tests
+
+**File:** `ManifestRepository.Integration.Tests.ps1`
+
+These tests use actual file I/O with test manifest directories.
+
+| Test | Description | Test Manifest |
+|------|-------------|---------------|
+| Save to new manifest | Creates manifest file, app directory, app.json | dynamic |
+| Save to existing manifest | Adds second app while preserving first | dynamic |
+| Save duplicate (idempotent) | Same AppId saved twice, no changes | dynamic |
+| Load single app | Loads specific app by ID | `multiple-apps.manifest.json` |
+| Load Gitconfig apps | Parses GitconfigApp correctly | `gitconfig.manifest.json` |
+| Load GitRepo apps | Parses GitRepoApp with scripts containing clone dir, excludes misconfigured | `git-repo.manifest.json` |
+| Load NonPackage apps | Parses NonPackageApp | `non-package.manifest.json` |
+| Load PowerShell apps | Parses with file-based scripts (install, upgrade, verification) | `powershell.manifest.json` |
+| Load PowerShell apps (missing non-install scripts) | Upgrade/verification null when files missing | `powershell.manifest.json` |
+| Load PowerShell apps (missing install script) | App excluded from manifest | `powershell.manifest.json` |
+| Load PowerShellAppPackage apps | Parses with downloader fields, preventUpgrade | `power-shell-app-packages.manifest.json` |
+| Load PowerShellModule apps (basic) | Parses with empty installArgs | `power-shell-module.manifest.json` |
+| Load PowerShellModule apps (with installArgs) | InstallArgs = " install-args" | `power-shell-module.manifest.json` |
+| Load PowerShellModule apps (with preventUpgrade) | PreventUpgrade = true | `power-shell-module.manifest.json` |
+| Load PowerShellModule apps (with configuration) | Registry settings parsed | `power-shell-module.manifest.json` |
+| Load Scoop apps (basic) | Parses correctly | `scoop.manifest.json` |
+| Load Scoop apps (with installArgs) | " install-args" | `scoop.manifest.json` |
+| Load Scoop apps (with preventUpgrade) | true | `scoop.manifest.json` |
+| Load Scoop apps (with configuration) | Registry settings | `scoop.manifest.json` |
+| Load ScoopBucket apps | Parses correctly | `scoop-bucket.manifest.json` |
+| Load Script apps (basic) | InstallScript, VerificationScript, UpgradeScript | `script.manifest.json` |
+| Load Script apps (with configuration) | Registry settings | `script.manifest.json` |
+| Load VisualStudioExtension apps | DownloaderArgs with Publisher and ExtensionName | `visual-studio-extension.manifest.json` |
+| Load Winget apps (basic) | Empty installArgs, no preventUpgrade | `winget.manifest.json` |
+| Load Winget apps (with installArgs) | " --override install-args" | `winget.manifest.json` |
+| Load Winget apps (with preventUpgrade) | true | `winget.manifest.json` |
+| Load Winget apps (with configuration) | Registry settings | `winget.manifest.json` |
+| Load Unknown apps | Excluded (empty list) | `unknown.manifest.json` |
+| Load with registry settings (string) | String ValueData | `registry-settings.manifest.json` |
+| Load with registry settings (tokenized string) | `{{env:ProgramFiles}}` replaced | `registry-settings.manifest.json` |
+| Load with registry settings (uint) | UInt32 ValueData | `registry-settings.manifest.json` |
+| Load with no specified environments | All apps loaded | `multiple-apps.manifest.json` |
+| Load for specific environment | Only matching apps | `multiple-apps.manifest.json` |
+| Load for multiple environments | Apps matching any | `multiple-apps.manifest.json` |
+
+### Settings Integration Tests
+
+**File:** `Settings.Integration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| InMemorySettingsRepository - load before save | Returns sensible test defaults |
+| InMemorySettingsRepository - load after save | Returns saved settings |
+
+### DependencyBootstrapper Integration Tests
+
+**File:** `DependencyBootstrapper.Integration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Initialize | Static dependencies (Tokenizer) are set up correctly |
+
+### ProcessRunner Integration Tests
+
+**File:** `ProcessRunner.Integration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Basic execution | `Write-Host 'Hello World'` exits 0 |
+| JSON output | Multi-variable script outputs valid JSON, parseable to object |
+| Admin execution | RunAsAdmin=true, exit code 0, no captured output |
+| Output capture | Multiple Write-Output lines captured in AllOutput, LastOutput = last line |
+| Error capture | Write-Error lines captured in Errors, cleaned of ANSI sequences |
+
+### Registry Integration Tests
+
+**File:** `Registry.Integration.Tests.ps1`
+
+| Test | Description |
+|------|-------------|
+| Get registry value | Reads known Windows registry value |
+| Set string registry value | Writes and reads back a string value |
+| Set uint32 registry value | Writes and reads back a large uint32 value |
+
+---
+
+## Test Manifests to Recreate
+
+The following test manifest files and app.json structures must be recreated for integration tests. These are copied from `Configurator.IntegrationTests/TestManifests/`.
+
+### Manifest Files
+
+| File | Content (App IDs) |
+|------|-------------------|
+| `winget.manifest.json` | winget-app-id, winget-app-id-with-install-args, winget-app-id-with-prevent-upgrade, winget-app-id-with-configuration |
+| `scoop.manifest.json` | scoop-app-id, scoop-app-id-with-install-args, scoop-app-id-with-prevent-upgrade, scoop-app-id-with-configuration |
+| `scoop-bucket.manifest.json` | scoop-bucket-app-id |
+| `script.manifest.json` | script-app-id, script-app-id-with-configuration |
+| `powershell.manifest.json` | powershell-app-id-1, powershell-app-id-2, powershell-app-id-3 |
+| `power-shell-app-packages.manifest.json` | power-shell-app-package-app-id, power-shell-app-package-app-id-with-prevent-upgrade |
+| `power-shell-module.manifest.json` | power-shell-module-app-id, power-shell-module-app-id-with-install-args, power-shell-module-app-id-with-prevent-upgrade, power-shell-module-app-id-with-configuration |
+| `gitconfig.manifest.json` | gitconfig-app-id |
+| `git-repo.manifest.json` | git-repo-app-id, git-repo-app-id-missing-install-args, git-repo-app-id-blank-install-args |
+| `non-package.manifest.json` | non-package-app-id |
+| `visual-studio-extension.manifest.json` | visual-studio-extension-app-id |
+| `unknown.manifest.json` | unknown-app-id |
+| `multiple-apps.manifest.json` | environment-1-app-id-1, environment-1-app-id-2, environment-1-and-3-app-id-3, environment-2-app-id-1, environment-3-app-id-1 |
+| `registry-settings.manifest.json` | registry-settings-app-id |
+
+### PowerShell App Script Files
+
+- `apps/powershell-app-id-1/install.ps1` (exists, content not important for parsing test)
+- `apps/powershell-app-id-1/upgrade.ps1` (exists)
+- `apps/powershell-app-id-1/verification.ps1` (exists)
+- `apps/powershell-app-id-2/install.ps1` (exists, no upgrade/verification)
+- `apps/powershell-app-id-3/` (directory exists, NO install.ps1)
+
+---
+
+## What the C# Tests Cover vs. What's Missing
+
+### Well Covered
+
+- CLI argument parsing and routing
+- Settings load/save/list/set flows
+- App installation decision logic (verify -> install/upgrade)
+- Desktop shortcut cleanup
+- Download app flow
+- All app type manifest parsing (integration tests)
+- Environment filtering
+- Registry setting types (string, uint, tokenized string)
+- PowerShell execution wrapping (Core and Windows variants)
+- Self-installer download and move logic
+- System initialization step ordering
+- Error handling (privileges, missing settings, bad exit codes)
+
+### Not Covered / Gaps
+
+- **No end-to-end tests**: No tests that run the full CLI -> command -> install flow against real packages
+- **No actual PowerShell execution in unit tests**: All PS execution is mocked
+- **ScoopBucketApp verification bug**: The bug in the verification script is not caught by tests because the script is never actually executed (only mocked)
+- **VisualStudioExtensionApp install script bug**: The `$vsi0xInstaller` typo is not caught
+- **NonPackageApp relative path**: No test validates the working directory assumption
+- **Concurrent manifest writes**: No test for race conditions on manifest file updates
+- **Large manifest performance**: No test with 100+ apps (the real manifest has 127)
+- **Network failure handling**: GitHub API and VS Marketplace download failures are minimally tested
+- **ProcessRunner ANSI cleaning**: Only implicitly tested via integration tests

--- a/configurator-pwsh/src/Configurator.ps1
+++ b/configurator-pwsh/src/Configurator.ps1
@@ -1,56 +1,14 @@
-[CmdletBinding(DefaultParameterSetName = 'Help')]
+[CmdletBinding()]
 param(
-    [Parameter(ParameterSetName = 'Initialize', Mandatory)]
-    [switch]$Initialize,
+    [Parameter(Position = 0)]
+    [string]$Command,
 
-    [Parameter(ParameterSetName = 'ConfigureMachine', Mandatory)]
-    [Alias('configure')]
-    [switch]$ConfigureMachine,
-
-    [Parameter(ParameterSetName = 'ConfigureMachine')]
-    [Alias('e')]
-    [string]$Environments,
-
-    [Parameter(ParameterSetName = 'ConfigureMachine')]
-    [Alias('app')]
-    [string]$SingleAppId,
-
-    [Parameter(ParameterSetName = 'SettingsList', Mandatory)]
-    [switch]$SettingsList,
-
-    [Parameter(ParameterSetName = 'SettingsSet', Mandatory)]
-    [switch]$SettingsSet,
-
-    [Parameter(ParameterSetName = 'SettingsSet', Mandatory, Position = 0)]
-    [string]$SettingName,
-
-    [Parameter(ParameterSetName = 'SettingsSet', Mandatory, Position = 1)]
-    [string]$SettingValue,
-
-    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
-    [Alias('add')]
-    [switch]$AddApp,
-
-    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
-    [string]$AppId,
-
-    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
-    [string]$AppType,
-
-    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
-    [string]$AppEnvironments,
-
-    [Parameter(ParameterSetName = 'Backup', Mandatory)]
-    [switch]$Backup,
-
-    [Parameter(ParameterSetName = 'Help')]
-    [switch]$Help
+    [Parameter(ValueFromRemainingArguments)]
+    [string[]]$RemainingArgs
 )
 
 $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot 'Configurator.psd1') -Force
 
-# TODO: Implement CLI routing to Public functions based on parameter set
-# Check elevation, parse arguments, route to appropriate command
-throw "Not implemented"
+exit (Start-Configurator -Command $Command -RemainingArgs $RemainingArgs)

--- a/configurator-pwsh/src/Configurator.ps1
+++ b/configurator-pwsh/src/Configurator.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding(DefaultParameterSetName = 'Help')]
+param(
+    [Parameter(ParameterSetName = 'Initialize', Mandatory)]
+    [switch]$Initialize,
+
+    [Parameter(ParameterSetName = 'ConfigureMachine', Mandatory)]
+    [Alias('configure')]
+    [switch]$ConfigureMachine,
+
+    [Parameter(ParameterSetName = 'ConfigureMachine')]
+    [Alias('e')]
+    [string]$Environments,
+
+    [Parameter(ParameterSetName = 'ConfigureMachine')]
+    [Alias('app')]
+    [string]$SingleAppId,
+
+    [Parameter(ParameterSetName = 'SettingsList', Mandatory)]
+    [switch]$SettingsList,
+
+    [Parameter(ParameterSetName = 'SettingsSet', Mandatory)]
+    [switch]$SettingsSet,
+
+    [Parameter(ParameterSetName = 'SettingsSet', Mandatory, Position = 0)]
+    [string]$SettingName,
+
+    [Parameter(ParameterSetName = 'SettingsSet', Mandatory, Position = 1)]
+    [string]$SettingValue,
+
+    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
+    [Alias('add')]
+    [switch]$AddApp,
+
+    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
+    [string]$AppId,
+
+    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
+    [string]$AppType,
+
+    [Parameter(ParameterSetName = 'AddApp', Mandatory)]
+    [string]$AppEnvironments,
+
+    [Parameter(ParameterSetName = 'Backup', Mandatory)]
+    [switch]$Backup,
+
+    [Parameter(ParameterSetName = 'Help')]
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'Configurator.psd1') -Force
+
+# TODO: Implement CLI routing to Public functions based on parameter set
+# Check elevation, parse arguments, route to appropriate command
+throw "Not implemented"

--- a/configurator-pwsh/src/Configurator.psd1
+++ b/configurator-pwsh/src/Configurator.psd1
@@ -14,6 +14,7 @@
         'Set-ConfiguratorSetting'
         'Add-ConfiguratorApp'
         'Invoke-Backup'
+        'Start-Configurator'
     )
 
     CmdletsToExport   = @()

--- a/configurator-pwsh/src/Configurator.psd1
+++ b/configurator-pwsh/src/Configurator.psd1
@@ -1,0 +1,29 @@
+@{
+    RootModule        = 'Configurator.psm1'
+    ModuleVersion     = '0.0.1'
+    GUID              = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    Author            = 'Danny Warren'
+    CompanyName       = 'dannydwarren'
+    Description       = 'Windows machine configuration tool'
+    PowerShellVersion = '7.0'
+
+    FunctionsToExport = @(
+        'Invoke-Initialize'
+        'Invoke-ConfigureMachine'
+        'Get-ConfiguratorSettings'
+        'Set-ConfiguratorSetting'
+        'Add-ConfiguratorApp'
+        'Invoke-Backup'
+    )
+
+    CmdletsToExport   = @()
+    VariablesToExport  = @()
+    AliasesToExport    = @()
+
+    PrivateData = @{
+        PSData = @{
+            Tags       = @('Windows', 'Configuration', 'Machine', 'Setup')
+            ProjectUri = 'https://github.com/dannydwarren/configurator'
+        }
+    }
+}

--- a/configurator-pwsh/src/Configurator.psm1
+++ b/configurator-pwsh/src/Configurator.psm1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = 'Stop'
+
+$privatePath = Join-Path $PSScriptRoot 'Private'
+$publicPath = Join-Path $PSScriptRoot 'Public'
+
+Get-ChildItem -Path $privatePath -Recurse -Filter '*.ps1' | ForEach-Object {
+    . $_.FullName
+}
+
+Get-ChildItem -Path $publicPath -Recurse -Filter '*.ps1' | ForEach-Object {
+    . $_.FullName
+}
+
+$publicFunctions = Get-ChildItem -Path $publicPath -Recurse -Filter '*.ps1' |
+    ForEach-Object { $_.BaseName }
+
+Export-ModuleMember -Function $publicFunctions

--- a/configurator-pwsh/src/Private/AppTypes/New-GitHubAssetApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitHubAssetApp.ps1
@@ -5,11 +5,22 @@ function New-GitHubAssetApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - internal-only download app type (not exposed via manifest AppType)
-    # InstallScript: empty string (no-op)
-    # VerificationScript: $null
-    # UpgradeScript: $null
-    # PreventUpgrade: $true
-    # Downloader: GitHubAssetDownloader
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = if ($null -ne $RawApp.environments) { $RawApp.environments } else { '' }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'gitHubAsset'
+        Environments       = $environments
+        InstallScript      = ''
+        VerificationScript = $null
+        UpgradeScript      = $null
+        InstallArgs        = $null
+        PreventUpgrade     = $true
+        Configuration      = $null
+        IsDownloadApp      = $true
+        Downloader         = 'GitHubAssetDownloader'
+        DownloaderArgs     = $RawApp.downloaderArgs
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-GitHubAssetApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitHubAssetApp.ps1
@@ -1,0 +1,15 @@
+function New-GitHubAssetApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - internal-only download app type (not exposed via manifest AppType)
+    # InstallScript: empty string (no-op)
+    # VerificationScript: $null
+    # UpgradeScript: $null
+    # PreventUpgrade: $true
+    # Downloader: GitHubAssetDownloader
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
@@ -26,7 +26,7 @@ function New-GitRepoApp {
         $CloneRootDirectory += '\'
     }
 
-    $repoName = $installArgs.Replace('.git', '').Split('\', '/') | Select-Object -Last 1
+    $repoName = $installArgs.Replace('.git', '').Split([char[]]@('\', '/')) | Select-Object -Last 1
 
     [PSCustomObject]@{
         AppId              = $appId

--- a/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
@@ -8,11 +8,39 @@ function New-GitRepoApp {
         [string]$CloneRootDirectory
     )
 
-    # TODO: Implement - build PSCustomObject with git clone/pull scripts
-    # Return $null if InstallArgs is null/whitespace
-    # RepoName derived from InstallArgs: strip .git, split on / or \, take last segment
-    # Install: mkdir {CloneRootDirectory} -Force;pushd {CloneRootDirectory};git clone {InstallArgs};popd
-    # Verify:  Test-Path {CloneRootDirectory}{RepoName}
-    # Upgrade: pushd {CloneRootDirectory}{RepoName};git pull;popd
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+    $installArgs = $RawApp.installArgs
+
+    if ([string]::IsNullOrWhiteSpace($installArgs)) {
+        return $null
+    }
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $endsWithSlash = $CloneRootDirectory.EndsWith('\') -or $CloneRootDirectory.EndsWith('/')
+    if (-not $endsWithSlash) {
+        $CloneRootDirectory += '\'
+    }
+
+    $repoName = $installArgs.Replace('.git', '').Split('\', '/') | Select-Object -Last 1
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'gitRepo'
+        Environments       = $environments
+        InstallScript      = "mkdir $CloneRootDirectory -Force;pushd $CloneRootDirectory;git clone $installArgs;popd"
+        VerificationScript = "Test-Path $CloneRootDirectory$repoName"
+        UpgradeScript      = "pushd $CloneRootDirectory$repoName;git pull;popd"
+        InstallArgs        = $installArgs
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $null
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitRepoApp.ps1
@@ -1,0 +1,18 @@
+function New-GitRepoApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp,
+
+        [Parameter(Mandatory)]
+        [string]$CloneRootDirectory
+    )
+
+    # TODO: Implement - build PSCustomObject with git clone/pull scripts
+    # Return $null if InstallArgs is null/whitespace
+    # RepoName derived from InstallArgs: strip .git, split on / or \, take last segment
+    # Install: mkdir {CloneRootDirectory} -Force;pushd {CloneRootDirectory};git clone {InstallArgs};popd
+    # Verify:  Test-Path {CloneRootDirectory}{RepoName}
+    # Upgrade: pushd {CloneRootDirectory}{RepoName};git pull;popd
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-GitconfigApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitconfigApp.ps1
@@ -5,9 +5,24 @@ function New-GitconfigApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with git config include.path commands
-    # Install: git config --global --add include.path {AppId}
-    # Verify:  (git config --get-all --global include.path) -match "{AppId}"  (backslashes escaped/doubled)
-    # Upgrade: $null
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $escapedAppId = $appId.Replace('\', '\\')
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'gitconfig'
+        Environments       = $environments
+        InstallScript      = "git config --global --add include.path $appId"
+        VerificationScript = "(git config --get-all --global include.path) -match `"$escapedAppId`""
+        UpgradeScript      = $null
+        InstallArgs        = $null
+        PreventUpgrade     = $false
+        Configuration      = $null
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-GitconfigApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-GitconfigApp.ps1
@@ -1,0 +1,13 @@
+function New-GitconfigApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with git config include.path commands
+    # Install: git config --global --add include.path {AppId}
+    # Verify:  (git config --get-all --global include.path) -match "{AppId}"  (backslashes escaped/doubled)
+    # Upgrade: $null
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-NonPackageApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-NonPackageApp.ps1
@@ -1,0 +1,13 @@
+function New-NonPackageApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with convention-based install script
+    # Install: ./{AppId}_install.ps1
+    # Verify:  $null
+    # Upgrade: $null
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-NonPackageApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-NonPackageApp.ps1
@@ -5,9 +5,22 @@ function New-NonPackageApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with convention-based install script
-    # Install: ./{AppId}_install.ps1
-    # Verify:  $null
-    # Upgrade: $null
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'nonPackageApp'
+        Environments       = $environments
+        InstallScript      = "./$($appId)_install.ps1"
+        VerificationScript = $null
+        UpgradeScript      = $null
+        InstallArgs        = $null
+        PreventUpgrade     = $false
+        Configuration      = $null
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellApp.ps1
@@ -8,9 +8,35 @@ function New-PowerShellApp {
         [string]$ManifestDirectory
     )
 
-    # TODO: Implement - load scripts from files in apps/<appId>/ directory
-    # Install:      . "<manifest>/apps/<appId>/install.ps1"   (required - return $null if missing)
-    # Upgrade:      . "<manifest>/apps/<appId>/upgrade.ps1"   (optional)
-    # Verification: . "<manifest>/apps/<appId>/verification.ps1" (optional)
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $appDir = Join-Path $ManifestDirectory 'apps' $appId
+    $installPath = Join-Path $appDir 'install.ps1'
+    $upgradePath = Join-Path $appDir 'upgrade.ps1'
+    $verificationPath = Join-Path $appDir 'verification.ps1'
+
+    if (-not (Test-Path $installPath)) {
+        return $null
+    }
+
+    $installScript = ". `"$installPath`""
+    $upgradeScript = if (Test-Path $upgradePath) { ". `"$upgradePath`"" } else { $null }
+    $verificationScript = if (Test-Path $verificationPath) { ". `"$verificationPath`"" } else { $null }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'powerShell'
+        Environments       = $environments
+        InstallScript      = $installScript
+        VerificationScript = $verificationScript
+        UpgradeScript      = $upgradeScript
+        InstallArgs        = $null
+        PreventUpgrade     = $false
+        Configuration      = $null
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellApp.ps1
@@ -1,0 +1,16 @@
+function New-PowerShellApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp,
+
+        [Parameter(Mandatory)]
+        [string]$ManifestDirectory
+    )
+
+    # TODO: Implement - load scripts from files in apps/<appId>/ directory
+    # Install:      . "<manifest>/apps/<appId>/install.ps1"   (required - return $null if missing)
+    # Upgrade:      . "<manifest>/apps/<appId>/upgrade.ps1"   (optional)
+    # Verification: . "<manifest>/apps/<appId>/verification.ps1" (optional)
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
@@ -13,7 +13,7 @@ function New-PowerShellAppPackageApp {
         $preventUpgrade = [bool]$RawApp.preventUpgrade
     }
 
-    $installScript = "Import-Module appx -UseWindowsPowerShell`nAdd-AppPackage `$DownloadedFilePath"
+    $installScript = "Import-Module appx -UseWindowsPowerShell`nAdd-AppPackage {{DownloadedFilePath}}"
     $verificationScript = "Import-Module appx -UseWindowsPowerShell`n(Get-AppPackage -Name $appId) -ne `$null"
 
     [PSCustomObject]@{

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
@@ -5,10 +5,30 @@ function New-PowerShellAppPackageApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with Add-AppPackage scripts, implements download app pattern
-    # Install: Import-Module appx -UseWindowsPowerShell\nAdd-AppPackage {DownloadedFilePath}
-    # Verify:  Import-Module appx -UseWindowsPowerShell\n(Get-AppPackage -Name {AppId}) -ne $null
-    # Upgrade: same as Install
-    # Downloader/DownloaderArgs from app.json
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $installScript = "Import-Module appx -UseWindowsPowerShell`nAdd-AppPackage `$DownloadedFilePath"
+    $verificationScript = "Import-Module appx -UseWindowsPowerShell`n(Get-AppPackage -Name $appId) -ne `$null"
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'powerShellAppPackage'
+        Environments       = $environments
+        InstallScript      = $installScript
+        VerificationScript = $verificationScript
+        UpgradeScript      = $installScript
+        InstallArgs        = $null
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $null
+        IsDownloadApp      = $true
+        Downloader         = $RawApp.downloader
+        DownloaderArgs     = $RawApp.downloaderArgs
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellAppPackageApp.ps1
@@ -1,0 +1,14 @@
+function New-PowerShellAppPackageApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with Add-AppPackage scripts, implements download app pattern
+    # Install: Import-Module appx -UseWindowsPowerShell\nAdd-AppPackage {DownloadedFilePath}
+    # Verify:  Import-Module appx -UseWindowsPowerShell\n(Get-AppPackage -Name {AppId}) -ne $null
+    # Upgrade: same as Install
+    # Downloader/DownloaderArgs from app.json
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellModuleApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellModuleApp.ps1
@@ -1,0 +1,14 @@
+function New-PowerShellModuleApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with Install-Module / Update-Module scripts
+    # InstallArgs: if non-empty, prepend " "
+    # Install: Import-Module PowerShellGet -UseWindowsPowerShell\nInstall-Module -Name {AppId}{InstallArgs}
+    # Verify:  (Get-Module -ListAvailable {AppId}) -ne $null
+    # Upgrade: Import-Module PowerShellGet -UseWindowsPowerShell\nUpdate-Module -Name {AppId}{InstallArgs}
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-PowerShellModuleApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-PowerShellModuleApp.ps1
@@ -5,10 +5,37 @@ function New-PowerShellModuleApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with Install-Module / Update-Module scripts
-    # InstallArgs: if non-empty, prepend " "
-    # Install: Import-Module PowerShellGet -UseWindowsPowerShell\nInstall-Module -Name {AppId}{InstallArgs}
-    # Verify:  (Get-Module -ListAvailable {AppId}) -ne $null
-    # Upgrade: Import-Module PowerShellGet -UseWindowsPowerShell\nUpdate-Module -Name {AppId}{InstallArgs}
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $installArgs = ''
+    if (-not [string]::IsNullOrWhiteSpace($RawApp.installArgs)) {
+        $installArgs = " $($RawApp.installArgs)"
+    }
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $configuration = $null
+    if ($null -ne $RawApp.configuration) {
+        $configuration = $RawApp.configuration
+    }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'powerShellModule'
+        Environments       = $environments
+        InstallScript      = "Import-Module PowerShellGet -UseWindowsPowerShell`nInstall-Module -Name $appId$installArgs"
+        VerificationScript = "(Get-Module -ListAvailable $appId) -ne `$null"
+        UpgradeScript      = "Import-Module PowerShellGet -UseWindowsPowerShell`nUpdate-Module -Name $appId$installArgs"
+        InstallArgs        = $installArgs
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $configuration
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-ScoopApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScoopApp.ps1
@@ -5,10 +5,37 @@ function New-ScoopApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with Install/Verify/Upgrade scripts using scoop commands
-    # InstallArgs: if non-empty, prepend " "
-    # Install: scoop install {AppId}{InstallArgs}
-    # Verify:  (scoop export | Select-String {AppId}) -ne $null
-    # Upgrade: scoop update {AppId}
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $installArgs = ''
+    if (-not [string]::IsNullOrWhiteSpace($RawApp.installArgs)) {
+        $installArgs = " $($RawApp.installArgs)"
+    }
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $configuration = $null
+    if ($null -ne $RawApp.configuration) {
+        $configuration = $RawApp.configuration
+    }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'scoop'
+        Environments       = $environments
+        InstallScript      = "scoop install $appId$installArgs"
+        VerificationScript = "(scoop export | Select-String $appId) -ne `$null"
+        UpgradeScript      = "scoop update $appId"
+        InstallArgs        = $installArgs
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $configuration
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-ScoopApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScoopApp.ps1
@@ -1,0 +1,14 @@
+function New-ScoopApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with Install/Verify/Upgrade scripts using scoop commands
+    # InstallArgs: if non-empty, prepend " "
+    # Install: scoop install {AppId}{InstallArgs}
+    # Verify:  (scoop export | Select-String {AppId}) -ne $null
+    # Upgrade: scoop update {AppId}
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-ScoopBucketApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScoopBucketApp.ps1
@@ -5,9 +5,22 @@ function New-ScoopBucketApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with scoop bucket commands
-    # Install: scoop bucket add {AppId}
-    # Verify:  (scoop bucket list | Select-String {AppId}) -ne $null  (FIX: properly interpolate AppId)
-    # Upgrade: $null
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'scoopBucket'
+        Environments       = $environments
+        InstallScript      = "scoop bucket add $appId"
+        VerificationScript = "(scoop bucket list | Select-String '$appId') -ne `$null"
+        UpgradeScript      = $null
+        InstallArgs        = $null
+        PreventUpgrade     = $false
+        Configuration      = $null
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-ScoopBucketApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScoopBucketApp.ps1
@@ -1,0 +1,13 @@
+function New-ScoopBucketApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with scoop bucket commands
+    # Install: scoop bucket add {AppId}
+    # Verify:  (scoop bucket list | Select-String {AppId}) -ne $null  (FIX: properly interpolate AppId)
+    # Upgrade: $null
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-ScriptApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScriptApp.ps1
@@ -5,7 +5,27 @@ function New-ScriptApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with inline scripts from app.json fields
-    # installScript, verificationScript, upgradeScript taken directly from JSON
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $configuration = $null
+    if ($null -ne $RawApp.configuration) {
+        $configuration = $RawApp.configuration
+    }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'script'
+        Environments       = $environments
+        InstallScript      = $RawApp.installScript
+        VerificationScript = $RawApp.verificationScript
+        UpgradeScript      = $RawApp.upgradeScript
+        InstallArgs        = $null
+        PreventUpgrade     = $false
+        Configuration      = $configuration
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-ScriptApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-ScriptApp.ps1
@@ -1,0 +1,11 @@
+function New-ScriptApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with inline scripts from app.json fields
+    # installScript, verificationScript, upgradeScript taken directly from JSON
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
@@ -15,7 +15,7 @@ function New-VisualStudioExtensionApp {
 
     $installScript = @'
 $vsixInstaller = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property productPath | Split-Path | % { "$_\VSIXInstaller.exe" }
-$installArgs = "/quiet", "/admin", "$DownloadedFilePath"
+$installArgs = "/quiet", "/admin", "{{DownloadedFilePath}}"
 Start-Process $vsixInstaller $installArgs -Wait
 '@
 

--- a/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
@@ -1,0 +1,14 @@
+function New-VisualStudioExtensionApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with VSIXInstaller commands, implements download app pattern
+    # Downloader: VisualStudioMarketplaceDownloader (hardcoded)
+    # Install script uses vswhere.exe to find VSIXInstaller.exe (FIX: $vsixInstaller not $vsi0xInstaller)
+    # Verify: $null
+    # Upgrade: same as Install
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-VisualStudioExtensionApp.ps1
@@ -5,10 +5,33 @@ function New-VisualStudioExtensionApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with VSIXInstaller commands, implements download app pattern
-    # Downloader: VisualStudioMarketplaceDownloader (hardcoded)
-    # Install script uses vswhere.exe to find VSIXInstaller.exe (FIX: $vsixInstaller not $vsi0xInstaller)
-    # Verify: $null
-    # Upgrade: same as Install
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $installScript = @'
+$vsixInstaller = . "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -property productPath | Split-Path | % { "$_\VSIXInstaller.exe" }
+$installArgs = "/quiet", "/admin", "$DownloadedFilePath"
+Start-Process $vsixInstaller $installArgs -Wait
+'@
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'visualStudioExtension'
+        Environments       = $environments
+        InstallScript      = $installScript
+        VerificationScript = $null
+        UpgradeScript      = $installScript
+        InstallArgs        = $null
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $null
+        IsDownloadApp      = $true
+        Downloader         = 'VisualStudioMarketplaceDownloader'
+        DownloaderArgs     = $RawApp.downloaderArgs
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/AppTypes/New-WingetApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-WingetApp.ps1
@@ -1,0 +1,14 @@
+function New-WingetApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp
+    )
+
+    # TODO: Implement - build PSCustomObject with Install/Verify/Upgrade scripts using winget commands
+    # InstallArgs: if non-empty, prepend " --override "
+    # Install: winget install --id {AppId} --accept-package-agreements -h -e{InstallArgs}
+    # Verify:  (winget list --id {AppId} -e | Select-String {AppId}) -ne $null
+    # Upgrade: winget upgrade --id {AppId} --accept-package-agreements -h -e{InstallArgs}
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/AppTypes/New-WingetApp.ps1
+++ b/configurator-pwsh/src/Private/AppTypes/New-WingetApp.ps1
@@ -5,10 +5,37 @@ function New-WingetApp {
         [PSCustomObject]$RawApp
     )
 
-    # TODO: Implement - build PSCustomObject with Install/Verify/Upgrade scripts using winget commands
-    # InstallArgs: if non-empty, prepend " --override "
-    # Install: winget install --id {AppId} --accept-package-agreements -h -e{InstallArgs}
-    # Verify:  (winget list --id {AppId} -e | Select-String {AppId}) -ne $null
-    # Upgrade: winget upgrade --id {AppId} --accept-package-agreements -h -e{InstallArgs}
-    throw "Not implemented"
+    $appId = $RawApp.appId
+    $environments = $RawApp.environments
+
+    $installArgs = ''
+    if (-not [string]::IsNullOrWhiteSpace($RawApp.installArgs)) {
+        $installArgs = " --override $($RawApp.installArgs)"
+    }
+
+    $preventUpgrade = $false
+    if ($null -ne $RawApp.preventUpgrade) {
+        $preventUpgrade = [bool]$RawApp.preventUpgrade
+    }
+
+    $configuration = $null
+    if ($null -ne $RawApp.configuration) {
+        $configuration = $RawApp.configuration
+    }
+
+    [PSCustomObject]@{
+        AppId              = $appId
+        AppType            = 'winget'
+        Environments       = $environments
+        InstallScript      = "winget install --id $appId --accept-package-agreements -h -e$installArgs"
+        VerificationScript = "(winget list --id $appId -e | Select-String $appId) -ne `$null"
+        UpgradeScript      = "winget upgrade --id $appId --accept-package-agreements -h -e$installArgs"
+        InstallArgs        = $installArgs
+        PreventUpgrade     = $preventUpgrade
+        Configuration      = $configuration
+        IsDownloadApp      = $false
+        Downloader         = $null
+        DownloaderArgs     = $null
+        DownloadedFilePath = $null
+    }
 }

--- a/configurator-pwsh/src/Private/Downloaders/Get-GitHubAsset.ps1
+++ b/configurator-pwsh/src/Private/Downloaders/Get-GitHubAsset.ps1
@@ -1,0 +1,10 @@
+function Get-GitHubAsset {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ArgsJson
+    )
+
+    # TODO: Implement - parse User/Repo/Extension from JSON, query GitHub API for latest release asset, download via Get-Download
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Downloaders/Get-GitHubAsset.ps1
+++ b/configurator-pwsh/src/Private/Downloaders/Get-GitHubAsset.ps1
@@ -2,9 +2,23 @@ function Get-GitHubAsset {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$ArgsJson
+        [PSCustomObject]$DownloaderArgs
     )
 
-    # TODO: Implement - parse User/Repo/Extension from JSON, query GitHub API for latest release asset, download via Get-Download
-    throw "Not implemented"
+    $user = $DownloaderArgs.User
+    $repo = $DownloaderArgs.Repo
+    $extension = $DownloaderArgs.Extension
+
+    $getAssetInfoScript = @"
+`$asset = (Invoke-WebRequest https://api.github.com/repos/$user/$repo/releases/latest | ConvertFrom-Json).assets | Where-Object { `$_.name -like '*$extension' }
+`$downloadUrl = `$asset | Select-Object -ExpandProperty browser_download_url
+`$fileName = `$asset | Select-Object -ExpandProperty name
+Write-Output "{ ``"FileName``": ``"`$fileName``", ``"Url``": ``"`$downloadUrl``" }"
+"@
+
+    $result = Invoke-PowerShellScript -Script $getAssetInfoScript -ResultType ([string])
+    $assetInfo = $result | ConvertFrom-Json
+
+    $settings = Import-Settings
+    Get-Download -Url $assetInfo.Url -FileName $assetInfo.FileName -DownloadsDirectory $settings.downloadsDirectory
 }

--- a/configurator-pwsh/src/Private/Downloaders/Get-VisualStudioExtension.ps1
+++ b/configurator-pwsh/src/Private/Downloaders/Get-VisualStudioExtension.ps1
@@ -1,0 +1,10 @@
+function Get-VisualStudioExtension {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ArgsJson
+    )
+
+    # TODO: Implement - parse Publisher/ExtensionName from JSON, fetch marketplace page, regex match download URL, download as .vsix
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Downloaders/Get-VisualStudioExtension.ps1
+++ b/configurator-pwsh/src/Private/Downloaders/Get-VisualStudioExtension.ps1
@@ -2,9 +2,22 @@ function Get-VisualStudioExtension {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string]$ArgsJson
+        [PSCustomObject]$DownloaderArgs
     )
 
-    # TODO: Implement - parse Publisher/ExtensionName from JSON, fetch marketplace page, regex match download URL, download as .vsix
-    throw "Not implemented"
+    $publisher = $DownloaderArgs.Publisher
+    $extensionName = $DownloaderArgs.ExtensionName
+
+    $pageUrl = "https://marketplace.visualstudio.com/items?itemName=$publisher.$extensionName"
+    $pageResponse = Invoke-WebRequest -Uri $pageUrl -UseBasicParsing
+    $pageHtml = $pageResponse.Content
+
+    $versionedUrlPattern = "/_apis/public/gallery/publishers/$publisher/vsextensions/$extensionName/(\d+\.?)+/vspackage"
+    $match = [regex]::Match($pageHtml, $versionedUrlPattern)
+    $downloadUrl = "https://marketplace.visualstudio.com$($match.Value)"
+
+    $fileName = "$publisher.$extensionName.vsix"
+
+    $settings = Import-Settings
+    Get-Download -Url $downloadUrl -FileName $fileName -DownloadsDirectory $settings.downloadsDirectory
 }

--- a/configurator-pwsh/src/Private/Initializer/Initialize-System.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Initialize-System.ps1
@@ -2,15 +2,15 @@ function Initialize-System {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement 9-step initialization sequence:
-    # 1. Set Windows PowerShell execution policy
-    # 2. Upgrade Winget
-    # 3. Accept Winget source agreements
-    # 4. Install PowerShell Core (via Windows PowerShell)
-    # 5. Set PowerShell Core execution policy
-    # 6. Self-install
-    # 7. Install Scoop CLI
-    # 8. Install Git
-    # 9. Install manifest repo
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    Set-PowerShellPolicy -Edition Windows
+    Set-WingetConfiguration -Action Upgrade
+    Set-WingetConfiguration -Action AcceptSourceAgreements
+    Install-PowerShellCore
+    Set-PowerShellPolicy -Edition Core
+    Install-Self
+    Install-ScoopCli
+    Install-Git
+    Install-ManifestRepo
 }

--- a/configurator-pwsh/src/Private/Initializer/Initialize-System.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Initialize-System.ps1
@@ -1,0 +1,16 @@
+function Initialize-System {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement 9-step initialization sequence:
+    # 1. Set Windows PowerShell execution policy
+    # 2. Upgrade Winget
+    # 3. Accept Winget source agreements
+    # 4. Install PowerShell Core (via Windows PowerShell)
+    # 5. Set PowerShell Core execution policy
+    # 6. Self-install
+    # 7. Install Scoop CLI
+    # 8. Install Git
+    # 9. Install manifest repo
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-Git.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-Git.ps1
@@ -1,0 +1,7 @@
+function Install-Git {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - install Git.Git via Winget using Install-App
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-Git.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-Git.ps1
@@ -2,6 +2,12 @@ function Install-Git {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - install Git.Git via Winget using Install-App
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $app = New-WingetApp -RawApp ([PSCustomObject]@{
+        appId        = 'Git.Git'
+        environments = ''
+    })
+
+    Install-App -App $app
 }

--- a/configurator-pwsh/src/Private/Initializer/Install-ManifestRepo.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-ManifestRepo.ps1
@@ -1,0 +1,7 @@
+function Install-ManifestRepo {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - load settings, throw if manifest.repo is null, install as GitRepoApp
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-ManifestRepo.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-ManifestRepo.ps1
@@ -2,6 +2,22 @@ function Install-ManifestRepo {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - load settings, throw if manifest.repo is null, install as GitRepoApp
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $settings = Import-Settings
+
+    $repoUri = $settings.manifest.repo
+    if ($null -eq $repoUri -or $repoUri -eq '') {
+        throw "Missing setting: Manifest.Repo"
+    }
+
+    $cloneDir = $settings.git.cloneDirectory
+
+    $app = New-GitRepoApp -RawApp ([PSCustomObject]@{
+        appId        = 'git.manifest-repo'
+        environments = ''
+        installArgs  = $repoUri.ToString()
+    }) -CloneRootDirectory $cloneDir.ToString()
+
+    Install-App -App $app
 }

--- a/configurator-pwsh/src/Private/Initializer/Install-PowerShellCore.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-PowerShellCore.ps1
@@ -2,6 +2,12 @@ function Install-PowerShellCore {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - install Microsoft.PowerShell WingetApp via Install-App -ForceWindowsPowerShell
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $app = New-WingetApp -RawApp ([PSCustomObject]@{
+        appId        = 'Microsoft.PowerShell'
+        environments = ''
+    })
+
+    Install-App -App $app -ForceWindowsPowerShell
 }

--- a/configurator-pwsh/src/Private/Initializer/Install-PowerShellCore.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-PowerShellCore.ps1
@@ -1,0 +1,7 @@
+function Install-PowerShellCore {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - install Microsoft.PowerShell WingetApp via Install-App -ForceWindowsPowerShell
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-ScoopCli.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-ScoopCli.ps1
@@ -2,6 +2,30 @@ function Install-ScoopCli {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - install Scoop via ScriptApp (iwr get.scoop.sh, verify via Get-Command scoop)
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $app = New-ScriptApp -RawApp ([PSCustomObject]@{
+        appId              = 'ScoopCli'
+        environments       = ''
+        installScript      = @"
+iwr get.scoop.sh -OutFile `$env:tmp\scoop-install.ps1
+& `$env:tmp\scoop-install.ps1 -RunAsAdmin
+"@
+        verificationScript = @"
+function Test-CommandExists
+{
+    param (`$command)
+    `$oldPreference = `$ErrorActionPreference
+    `$ErrorActionPreference = 'stop'
+    try {if(Get-Command `$command){return `$true}}
+    catch {return `$false}
+    finally {`$ErrorActionPreference=`$oldPreference}
+}
+
+Test-CommandExists scoop
+"@
+        upgradeScript      = $null
+    })
+
+    Install-App -App $app
 }

--- a/configurator-pwsh/src/Private/Initializer/Install-ScoopCli.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-ScoopCli.ps1
@@ -1,0 +1,7 @@
+function Install-ScoopCli {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - install Scoop via ScriptApp (iwr get.scoop.sh, verify via Get-Command scoop)
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-Self.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-Self.ps1
@@ -1,0 +1,7 @@
+function Install-Self {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - check if install dir exists, download module from GitHub, extract, add to PATH and PSModulePath
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Install-Self.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Install-Self.ps1
@@ -2,6 +2,40 @@ function Install-Self {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - check if install dir exists, download module from GitHub, extract, add to PATH and PSModulePath
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $installDir = 'c:\Configurator'
+
+    if (Test-Path $installDir) {
+        return
+    }
+
+    $app = New-GitHubAssetApp -RawApp ([PSCustomObject]@{
+        appId          = 'Configurator'
+        downloaderArgs = [PSCustomObject]@{
+            User      = 'dannydwarren'
+            Repo      = 'configurator'
+            Extension = '.exe'
+        }
+    })
+
+    Install-DownloadApp -App $app
+
+    New-Item -Path $installDir -ItemType Directory -Force | Out-Null
+    Move-Item -Path $app.DownloadedFilePath -Destination (Join-Path $installDir 'Configurator.exe') -Force
+
+    Add-ToMachinePath -Directory $installDir
+}
+
+function Add-ToMachinePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Directory
+    )
+
+    $machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+    if ($machinePath -notlike "*$Directory*") {
+        [System.Environment]::SetEnvironmentVariable('Path', "$machinePath;$Directory", 'Machine')
+    }
 }

--- a/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
@@ -8,8 +8,8 @@ function Set-PowerShellPolicy {
 
     $ErrorActionPreference = 'Stop'
 
-    $setPolicyScript = 'Set-ExecutionPolicy RemoteSigned -Force'
-    $getPolicyScript = 'Get-ExecutionPolicy'
+    $setPolicyScript = 'Import-Module Microsoft.PowerShell.Security -ErrorAction SilentlyContinue; Set-ExecutionPolicy RemoteSigned -Force'
+    $getPolicyScript = 'Import-Module Microsoft.PowerShell.Security -ErrorAction SilentlyContinue; Get-ExecutionPolicy'
     $getVersionScript = '$PSVersionTable.PSVersion.ToString()'
 
     if ($Edition -eq 'Core') {

--- a/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
@@ -1,0 +1,11 @@
+function Set-PowerShellPolicy {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Core', 'Windows')]
+        [string]$Edition
+    )
+
+    # TODO: Implement - Set-ExecutionPolicy RemoteSigned -Force (admin), report policy and version
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-PowerShellPolicy.ps1
@@ -6,6 +6,26 @@ function Set-PowerShellPolicy {
         [string]$Edition
     )
 
-    # TODO: Implement - Set-ExecutionPolicy RemoteSigned -Force (admin), report policy and version
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $setPolicyScript = 'Set-ExecutionPolicy RemoteSigned -Force'
+    $getPolicyScript = 'Get-ExecutionPolicy'
+    $getVersionScript = '$PSVersionTable.PSVersion.ToString()'
+
+    if ($Edition -eq 'Core') {
+        Invoke-PowerShellScript -Script $setPolicyScript -RunAsAdmin
+        $policyResult = Invoke-PowerShellScript -Script $getPolicyScript -ResultType ([string])
+        Write-ConfiguratorLog -Message "PowerShell Core - Execution Policy: $policyResult" -Level Result
+
+        $versionResult = Invoke-PowerShellScript -Script $getVersionScript -ResultType ([string])
+        Write-ConfiguratorLog -Message "PowerShell Core - Version: $versionResult" -Level Debug
+    }
+    else {
+        Invoke-WindowsPowerShellScript -Script $setPolicyScript -RunAsAdmin
+        $policyResult = Invoke-WindowsPowerShellScript -Script $getPolicyScript -ResultType ([string])
+        Write-ConfiguratorLog -Message "Windows PowerShell - Execution Policy: $policyResult" -Level Result
+
+        $versionResult = Invoke-WindowsPowerShellScript -Script $getVersionScript -ResultType ([string])
+        Write-ConfiguratorLog -Message "Windows PowerShell - Version: $versionResult" -Level Debug
+    }
 }

--- a/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
@@ -9,8 +9,18 @@ function Set-WingetConfiguration {
     $ErrorActionPreference = 'Stop'
 
     if ($Action -eq 'Upgrade') {
-        Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -ForceTargetApplicationShutdown'
-        Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://cdn.winget.microsoft.com/cache/source.msix'
+        try {
+            Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -ForceTargetApplicationShutdown'
+        }
+        catch {
+            Write-ConfiguratorLog -Message "Winget upgrade skipped: $_" -Level Debug
+        }
+        try {
+            Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://cdn.winget.microsoft.com/cache/source.msix'
+        }
+        catch {
+            Write-ConfiguratorLog -Message "Winget source update skipped: $_" -Level Debug
+        }
     }
     else {
         Invoke-WindowsPowerShellScript -Script 'winget list winget --accept-source-agreements'

--- a/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
@@ -1,0 +1,12 @@
+function Set-WingetConfiguration {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('Upgrade', 'AcceptSourceAgreements')]
+        [string]$Action
+    )
+
+    # TODO: Implement - Upgrade: Add-AppxPackage for winget msixbundle and source.msix via Windows PowerShell
+    # TODO: Implement - AcceptSourceAgreements: winget list winget --accept-source-agreements via Windows PowerShell
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
+++ b/configurator-pwsh/src/Private/Initializer/Set-WingetConfiguration.ps1
@@ -6,7 +6,13 @@ function Set-WingetConfiguration {
         [string]$Action
     )
 
-    # TODO: Implement - Upgrade: Add-AppxPackage for winget msixbundle and source.msix via Windows PowerShell
-    # TODO: Implement - AcceptSourceAgreements: winget list winget --accept-source-agreements via Windows PowerShell
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    if ($Action -eq 'Upgrade') {
+        Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://github.com/microsoft/winget-cli/releases/latest/download/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -ForceTargetApplicationShutdown'
+        Invoke-WindowsPowerShellScript -Script 'Add-AppxPackage https://cdn.winget.microsoft.com/cache/source.msix'
+    }
+    else {
+        Invoke-WindowsPowerShellScript -Script 'winget list winget --accept-source-agreements'
+    }
 }

--- a/configurator-pwsh/src/Private/Installer/Install-App.ps1
+++ b/configurator-pwsh/src/Private/Installer/Install-App.ps1
@@ -8,6 +8,53 @@ function Install-App {
         [switch]$ForceWindowsPowerShell
     )
 
-    # TODO: Implement verify -> install/upgrade -> re-verify -> configure -> delete shortcuts flow
-    throw "Not implemented"
+    Write-ConfiguratorLog -Message "Installing '$($App.AppId)'" -Level Info
+
+    $preInstallEntries = @(Get-DesktopEntries)
+
+    $preInstallVerified = $false
+    if ($null -ne $App.VerificationScript) {
+        if ($ForceWindowsPowerShell) {
+            $preInstallVerified = Invoke-WindowsPowerShellScript -Script $App.VerificationScript -ResultType ([bool])
+        }
+        else {
+            $preInstallVerified = Invoke-PowerShellScript -Script $App.VerificationScript -ResultType ([bool])
+        }
+    }
+
+    $actionScript = ''
+    if (-not $preInstallVerified) {
+        $actionScript = $App.InstallScript
+    }
+    elseif ($null -ne $App.UpgradeScript -and -not $App.PreventUpgrade) {
+        $actionScript = $App.UpgradeScript
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($actionScript)) {
+        if ($ForceWindowsPowerShell) {
+            Invoke-WindowsPowerShellScript -Script $actionScript
+        }
+        else {
+            Invoke-PowerShellScript -Script $actionScript
+        }
+
+        if ($null -ne $App.VerificationScript) {
+            $postInstallVerified = $false
+            if ($ForceWindowsPowerShell) {
+                $postInstallVerified = Invoke-WindowsPowerShellScript -Script $App.VerificationScript -ResultType ([bool])
+            }
+            else {
+                $postInstallVerified = Invoke-PowerShellScript -Script $App.VerificationScript -ResultType ([bool])
+            }
+
+            if (-not $postInstallVerified) {
+                Write-ConfiguratorLog -Message "Failed to install '$($App.AppId)'" -Level Debug
+            }
+        }
+    }
+
+    $postInstallEntries = @(Get-DesktopEntries)
+    Remove-DesktopShortcuts -BeforeEntries $preInstallEntries -AfterEntries $postInstallEntries
+
+    Write-ConfiguratorLog -Message "Installed '$($App.AppId)'" -Level Result
 }

--- a/configurator-pwsh/src/Private/Installer/Install-App.ps1
+++ b/configurator-pwsh/src/Private/Installer/Install-App.ps1
@@ -1,0 +1,13 @@
+function Install-App {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$App,
+
+        [Parameter()]
+        [switch]$ForceWindowsPowerShell
+    )
+
+    # TODO: Implement verify -> install/upgrade -> re-verify -> configure -> delete shortcuts flow
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
+++ b/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
@@ -1,0 +1,10 @@
+function Install-DownloadApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$App
+    )
+
+    # TODO: Implement - resolve downloader, download file, set DownloadedFilePath on app, delegate to Install-App
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
+++ b/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
@@ -25,6 +25,13 @@ function Install-DownloadApp {
 
     $App.DownloadedFilePath = $filePath
 
+    if ($App.InstallScript -match '\{\{DownloadedFilePath\}\}') {
+        $App.InstallScript = $App.InstallScript -replace '\{\{DownloadedFilePath\}\}', $filePath
+    }
+    if ($App.UpgradeScript -match '\{\{DownloadedFilePath\}\}') {
+        $App.UpgradeScript = $App.UpgradeScript -replace '\{\{DownloadedFilePath\}\}', $filePath
+    }
+
     Write-ConfiguratorLog -Message "Downloaded '$($App.AppId)'" -Level Result
 
     Install-App -App $App

--- a/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
+++ b/configurator-pwsh/src/Private/Installer/Install-DownloadApp.ps1
@@ -5,6 +5,27 @@ function Install-DownloadApp {
         [PSCustomObject]$App
     )
 
-    # TODO: Implement - resolve downloader, download file, set DownloadedFilePath on app, delegate to Install-App
-    throw "Not implemented"
+    Write-ConfiguratorLog -Message "Downloading '$($App.AppId)'" -Level Info
+
+    $downloaderName = $App.Downloader
+    $downloaderArgs = $App.DownloaderArgs
+
+    $filePath = $null
+    switch ($downloaderName) {
+        'GitHubAssetDownloader' {
+            $filePath = Get-GitHubAsset -DownloaderArgs $downloaderArgs
+        }
+        'VisualStudioMarketplaceDownloader' {
+            $filePath = Get-VisualStudioExtension -DownloaderArgs $downloaderArgs
+        }
+        default {
+            throw "Cannot find downloader '$downloaderName'"
+        }
+    }
+
+    $App.DownloadedFilePath = $filePath
+
+    Write-ConfiguratorLog -Message "Downloaded '$($App.AppId)'" -Level Result
+
+    Install-App -App $App
 }

--- a/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
+++ b/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
@@ -1,0 +1,17 @@
+function Invoke-AppConfigurator {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$App,
+
+        [Parameter()]
+        [switch]$Configure,
+
+        [Parameter()]
+        [switch]$Backup
+    )
+
+    # TODO: Implement - Configure: apply registry settings from app.Configuration
+    # TODO: Implement - Backup: verify app installed, run backup.ps1 if exists
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
+++ b/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
@@ -17,7 +17,11 @@ function Invoke-AppConfigurator {
         }
 
         foreach ($setting in $App.Configuration.registrySettings) {
-            Set-RegistryValue -KeyName $setting.keyName -ValueName $setting.valueName -ValueData $setting.valueData
+            $valueData = $setting.valueData
+            if ($valueData -is [string]) {
+                $valueData = Resolve-Token -Value $valueData
+            }
+            Set-RegistryValue -KeyName $setting.keyName -ValueName $setting.valueName -ValueData $valueData
         }
     }
 

--- a/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
+++ b/configurator-pwsh/src/Private/Installer/Invoke-AppConfigurator.ps1
@@ -11,7 +11,33 @@ function Invoke-AppConfigurator {
         [switch]$Backup
     )
 
-    # TODO: Implement - Configure: apply registry settings from app.Configuration
-    # TODO: Implement - Backup: verify app installed, run backup.ps1 if exists
-    throw "Not implemented"
+    if ($Configure) {
+        if ($null -eq $App.Configuration) {
+            return
+        }
+
+        foreach ($setting in $App.Configuration.registrySettings) {
+            Set-RegistryValue -KeyName $setting.keyName -ValueName $setting.valueName -ValueData $setting.valueData
+        }
+    }
+
+    if ($Backup) {
+        $isInstalled = $false
+        if (-not [string]::IsNullOrEmpty($App.VerificationScript)) {
+            $isInstalled = Invoke-PowerShellScript -Script $App.VerificationScript -ResultType ([bool])
+        }
+
+        if (-not $isInstalled) {
+            return
+        }
+
+        $settings = Import-Settings
+        $backupFilePath = Join-Path $settings.manifest.directory "apps" $App.AppId "backup.ps1"
+
+        if (Test-Path $backupFilePath) {
+            Write-ConfiguratorLog -Message "Backing up $($App.AppId)..." -Level Info
+            Invoke-PowerShellScript -Script $backupFilePath
+            Write-ConfiguratorLog -Message "Backed up $($App.AppId)!" -Level Result
+        }
+    }
 }

--- a/configurator-pwsh/src/Private/Manifest/ConvertTo-AppObject.ps1
+++ b/configurator-pwsh/src/Private/Manifest/ConvertTo-AppObject.ps1
@@ -1,0 +1,13 @@
+function ConvertTo-AppObject {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$RawApp,
+
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Settings
+    )
+
+    # TODO: Implement - switch on appType, route to New-*App function, return standardized PSCustomObject (or $null for unknown)
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Manifest/ConvertTo-AppObject.ps1
+++ b/configurator-pwsh/src/Private/Manifest/ConvertTo-AppObject.ps1
@@ -8,6 +8,18 @@ function ConvertTo-AppObject {
         [PSCustomObject]$Settings
     )
 
-    # TODO: Implement - switch on appType, route to New-*App function, return standardized PSCustomObject (or $null for unknown)
-    throw "Not implemented"
+    switch ($RawApp.appType) {
+        'winget' { return New-WingetApp -RawApp $RawApp }
+        'scoop' { return New-ScoopApp -RawApp $RawApp }
+        'scoopBucket' { return New-ScoopBucketApp -RawApp $RawApp }
+        'powerShell' { return New-PowerShellApp -RawApp $RawApp -ManifestDirectory $Settings.manifest.directory }
+        'powerShellModule' { return New-PowerShellModuleApp -RawApp $RawApp }
+        'powerShellAppPackage' { return New-PowerShellAppPackageApp -RawApp $RawApp }
+        'script' { return New-ScriptApp -RawApp $RawApp }
+        'gitRepo' { return New-GitRepoApp -RawApp $RawApp -CloneRootDirectory $Settings.git.cloneDirectory }
+        'gitconfig' { return New-GitconfigApp -RawApp $RawApp }
+        'nonPackageApp' { return New-NonPackageApp -RawApp $RawApp }
+        'visualStudioExtension' { return New-VisualStudioExtensionApp -RawApp $RawApp }
+        default { return $null }
+    }
 }

--- a/configurator-pwsh/src/Private/Manifest/Import-AppDefinition.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Import-AppDefinition.ps1
@@ -1,0 +1,13 @@
+function Import-AppDefinition {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [string]$ManifestDirectory
+    )
+
+    # TODO: Implement - read apps/<appId>/app.json, return raw PSCustomObject with AppData
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Manifest/Import-AppDefinition.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Import-AppDefinition.ps1
@@ -8,6 +8,10 @@ function Import-AppDefinition {
         [string]$ManifestDirectory
     )
 
-    # TODO: Implement - read apps/<appId>/app.json, return raw PSCustomObject with AppData
-    throw "Not implemented"
+    $appDir = Join-Path $ManifestDirectory 'apps' $AppId
+    $appFilePath = Join-Path $appDir 'app.json'
+    $json = Get-Content -Path $appFilePath -Raw
+    $raw = $json | ConvertFrom-Json
+
+    $raw
 }

--- a/configurator-pwsh/src/Private/Manifest/Import-Manifest.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Import-Manifest.ps1
@@ -1,0 +1,10 @@
+function Import-Manifest {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]$Environments = @()
+    )
+
+    # TODO: Implement - load settings, read manifest.json, load each app definition, filter by environments, parse into typed objects
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Manifest/Import-Manifest.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Import-Manifest.ps1
@@ -2,9 +2,85 @@ function Import-Manifest {
     [CmdletBinding()]
     param(
         [Parameter()]
-        [string[]]$Environments = @()
+        [string[]]$Environments = @(),
+
+        [Parameter()]
+        [string]$SingleAppId
     )
 
-    # TODO: Implement - load settings, read manifest.json, load each app definition, filter by environments, parse into typed objects
-    throw "Not implemented"
+    $settings = Import-Settings
+    $manifestDir = $settings.manifest.directory
+    $manifestFileName = $settings.manifest.fileName
+    $manifestFilePath = Join-Path $manifestDir $manifestFileName
+
+    if (-not (Test-Path $manifestFilePath)) {
+        Set-Content -Path $manifestFilePath -Value '{}' -Encoding UTF8
+    }
+
+    $manifestJson = Get-Content -Path $manifestFilePath -Raw | ConvertFrom-Json
+
+    $appIds = @()
+    if ($null -ne $manifestJson.apps) {
+        $appIds = @($manifestJson.apps)
+    }
+
+    $rawApps = foreach ($id in $appIds) {
+        Import-AppDefinition -AppId $id -ManifestDirectory $manifestDir
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SingleAppId)) {
+        $apps = @()
+        foreach ($raw in $rawApps) {
+            $app = ConvertTo-AppObject -RawApp $raw -Settings $settings
+            if ($null -ne $app) {
+                $apps += $app
+            }
+        }
+        $match = $apps | Where-Object { $_.AppId -eq $SingleAppId } | Select-Object -First 1
+        if ($null -ne $match) {
+            $apps = @($match)
+        }
+        else {
+            $apps = @()
+        }
+
+        return @{
+            AppIds = $appIds
+            Apps   = $apps
+        }
+    }
+
+    $filtered = foreach ($raw in $rawApps) {
+        $include = $false
+
+        if ($Environments.Count -eq 0) {
+            $include = $true
+        }
+        else {
+            $envLowered = $raw.environments.ToLower()
+            foreach ($env in $Environments) {
+                if ($envLowered.Contains($env.ToLower())) {
+                    $include = $true
+                    break
+                }
+            }
+        }
+
+        if ($include) {
+            $raw
+        }
+    }
+
+    $apps = @()
+    foreach ($raw in $filtered) {
+        $app = ConvertTo-AppObject -RawApp $raw -Settings $settings
+        if ($null -ne $app) {
+            $apps += $app
+        }
+    }
+
+    @{
+        AppIds = $appIds
+        Apps   = $apps
+    }
 }

--- a/configurator-pwsh/src/Private/Manifest/Save-AppDefinition.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Save-AppDefinition.ps1
@@ -1,0 +1,10 @@
+function Save-AppDefinition {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Installable
+    )
+
+    # TODO: Implement - check if app already in manifest (idempotent), create app dir, write app.json, add to manifest, write manifest
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Manifest/Save-AppDefinition.ps1
+++ b/configurator-pwsh/src/Private/Manifest/Save-AppDefinition.ps1
@@ -2,9 +2,54 @@ function Save-AppDefinition {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [PSCustomObject]$Installable
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [string]$AppType,
+
+        [Parameter(Mandatory)]
+        [string]$Environments
     )
 
-    # TODO: Implement - check if app already in manifest (idempotent), create app dir, write app.json, add to manifest, write manifest
-    throw "Not implemented"
+    $settings = Import-Settings
+    $manifestDir = $settings.manifest.directory
+    $manifestFileName = $settings.manifest.fileName
+    $manifestFilePath = Join-Path $manifestDir $manifestFileName
+
+    if (-not (Test-Path $manifestFilePath)) {
+        Set-Content -Path $manifestFilePath -Value '{}' -Encoding UTF8
+    }
+
+    $manifestJson = Get-Content -Path $manifestFilePath -Raw | ConvertFrom-Json
+
+    $appsList = @()
+    if ($null -ne $manifestJson.apps) {
+        $appsList = @($manifestJson.apps)
+    }
+
+    if ($appsList -contains $AppId) {
+        return
+    }
+
+    $appDir = Join-Path $manifestDir 'apps' $AppId
+    New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+
+    $appDefinition = [PSCustomObject]@{
+        appType      = $AppType
+        appId        = $AppId
+        environments = $Environments
+    }
+
+    $appJson = $appDefinition | ConvertTo-Json -Depth 10
+    $appFilePath = Join-Path $appDir 'app.json'
+    Set-Content -Path $appFilePath -Value $appJson -Encoding UTF8
+
+    $appsList += $AppId
+
+    $manifestFile = [PSCustomObject]@{
+        apps = $appsList
+    }
+
+    $manifestFileJson = $manifestFile | ConvertTo-Json -Depth 10
+    Set-Content -Path $manifestFilePath -Value $manifestFileJson -Encoding UTF8
 }

--- a/configurator-pwsh/src/Private/PowerShell/Find-PowerShellCore.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Find-PowerShellCore.ps1
@@ -2,6 +2,26 @@ function Find-PowerShellCore {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - read registry SOFTWARE\Microsoft\PowerShellCore\InstalledVersions, return pwsh.exe path
-    throw "Not implemented"
+    $installedVersionsKey = 'SOFTWARE\Microsoft\PowerShellCore\InstalledVersions'
+    $regKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($installedVersionsKey)
+
+    if ($null -eq $regKey) {
+        throw 'PowerShell Core is not installed. No versions found in registry.'
+    }
+
+    $subKeys = $regKey.GetSubKeyNames()
+    $regKey.Close()
+
+    if ($subKeys.Count -eq 0) {
+        throw 'PowerShell Core is not installed. No versions found in registry.'
+    }
+
+    $versionKey = "HKEY_LOCAL_MACHINE\$installedVersionsKey\$($subKeys[0])"
+    $installLocation = [Microsoft.Win32.Registry]::GetValue($versionKey, 'InstallLocation', $null)
+
+    if ([string]::IsNullOrEmpty($installLocation)) {
+        throw 'PowerShell Core is not installed. No versions found in registry.'
+    }
+
+    Join-Path $installLocation 'pwsh.exe'
 }

--- a/configurator-pwsh/src/Private/PowerShell/Find-PowerShellCore.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Find-PowerShellCore.ps1
@@ -1,0 +1,7 @@
+function Find-PowerShellCore {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - read registry SOFTWARE\Microsoft\PowerShellCore\InstalledVersions, return pwsh.exe path
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
@@ -11,6 +11,83 @@ function Invoke-PowerShellScript {
         [type]$ResultType
     )
 
-    # TODO: Implement - wrap script with env setup, write to temp file, execute via pwsh.exe, handle output/errors/exit code
-    throw "Not implemented"
+    $myDocumentsPath = [System.Environment]::GetFolderPath('MyDocuments')
+    $profilePath = Join-Path $myDocumentsPath 'PowerShell' 'Microsoft.PowerShell_profile.ps1'
+
+    $environmentReadyScript = @"
+`$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+if (`$profile -eq `$null -or `$profile -eq '') {
+  `$global:profile = "$profilePath"
+}
+
+$Script
+"@
+
+    $scriptFile = New-ScriptFile -Script $environmentReadyScript
+    $executable = Find-PowerShellCore
+
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = $executable
+    $startInfo.Arguments = "-File $scriptFile"
+    $startInfo.UseShellExecute = [bool]$RunAsAdmin
+    $startInfo.RedirectStandardOutput = -not $RunAsAdmin
+    $startInfo.RedirectStandardError = -not $RunAsAdmin
+    $startInfo.Verb = if ($RunAsAdmin) { 'runas' } else { 'open' }
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    $process.Start() | Out-Null
+
+    $lastOutput = $null
+    $allOutput = @()
+    $errors = @()
+
+    if (-not $RunAsAdmin) {
+        while (-not $process.StandardOutput.EndOfStream) {
+            $line = $process.StandardOutput.ReadLine()
+            if ($null -ne $line) {
+                $lastOutput = $line
+                $allOutput += $line
+                Write-ConfiguratorLog -Message $line -Level Debug
+            }
+        }
+
+        while (-not $process.StandardError.EndOfStream) {
+            $dirtyError = $process.StandardError.ReadLine()
+            if ($null -ne $dirtyError) {
+                $cleanError = $dirtyError -replace "$([char]27)\[91m", '' -replace "$([char]27)\[31;1m", '' -replace "$([char]27)\[0m", ''
+                $errors += $cleanError
+                Write-ConfiguratorLog -Message $cleanError -Level Debug
+            }
+        }
+    }
+
+    $process.WaitForExit()
+    $exitCode = $process.ExitCode
+    $process.Dispose()
+
+    foreach ($err in $errors) {
+        Write-ConfiguratorLog -Message $err -Level Error
+    }
+
+    if ($exitCode -ne 0) {
+        throw "Script failed to complete with exit code $exitCode"
+    }
+
+    if ($null -ne $ResultType) {
+        if ($null -eq $lastOutput) {
+            return $null
+        }
+
+        if ($ResultType -eq [string]) {
+            return $lastOutput
+        }
+        elseif ($ResultType -eq [bool]) {
+            return [bool]::Parse($lastOutput)
+        }
+        else {
+            throw "PowerShell result type of '$($ResultType.FullName)' is not yet supported"
+        }
+    }
 }

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
@@ -1,0 +1,16 @@
+function Invoke-PowerShellScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Script,
+
+        [Parameter()]
+        [switch]$RunAsAdmin,
+
+        [Parameter()]
+        [type]$ResultType
+    )
+
+    # TODO: Implement - wrap script with env setup, write to temp file, execute via pwsh.exe, handle output/errors/exit code
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-PowerShellScript.ps1
@@ -68,7 +68,9 @@ $Script
     $process.Dispose()
 
     foreach ($err in $errors) {
-        Write-ConfiguratorLog -Message $err -Level Error
+        if (-not [string]::IsNullOrWhiteSpace($err)) {
+            Write-ConfiguratorLog -Message $err -Level Error
+        }
     }
 
     if ($exitCode -ne 0) {

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
@@ -1,0 +1,16 @@
+function Invoke-WindowsPowerShellScript {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Script,
+
+        [Parameter()]
+        [switch]$RunAsAdmin,
+
+        [Parameter()]
+        [type]$ResultType
+    )
+
+    # TODO: Implement - same as Invoke-PowerShellScript but uses powershell.exe and WindowsPowerShell profile path
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
@@ -67,7 +67,9 @@ $Script
     $process.Dispose()
 
     foreach ($err in $errors) {
-        Write-ConfiguratorLog -Message $err -Level Error
+        if (-not [string]::IsNullOrWhiteSpace($err)) {
+            Write-ConfiguratorLog -Message $err -Level Error
+        }
     }
 
     if ($exitCode -ne 0) {

--- a/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/Invoke-WindowsPowerShellScript.ps1
@@ -11,6 +11,82 @@ function Invoke-WindowsPowerShellScript {
         [type]$ResultType
     )
 
-    # TODO: Implement - same as Invoke-PowerShellScript but uses powershell.exe and WindowsPowerShell profile path
-    throw "Not implemented"
+    $myDocumentsPath = [System.Environment]::GetFolderPath('MyDocuments')
+    $profilePath = Join-Path $myDocumentsPath 'WindowsPowerShell' 'Microsoft.PowerShell_profile.ps1'
+
+    $environmentReadyScript = @"
+`$env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+
+if (`$profile -eq `$null -or `$profile -eq '') {
+  `$global:profile = "$profilePath"
+}
+
+$Script
+"@
+
+    $scriptFile = New-ScriptFile -Script $environmentReadyScript
+
+    $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $startInfo.FileName = 'powershell.exe'
+    $startInfo.Arguments = "-File $scriptFile"
+    $startInfo.UseShellExecute = [bool]$RunAsAdmin
+    $startInfo.RedirectStandardOutput = -not $RunAsAdmin
+    $startInfo.RedirectStandardError = -not $RunAsAdmin
+    $startInfo.Verb = if ($RunAsAdmin) { 'runas' } else { 'open' }
+
+    $process = New-Object System.Diagnostics.Process
+    $process.StartInfo = $startInfo
+    $process.Start() | Out-Null
+
+    $lastOutput = $null
+    $allOutput = @()
+    $errors = @()
+
+    if (-not $RunAsAdmin) {
+        while (-not $process.StandardOutput.EndOfStream) {
+            $line = $process.StandardOutput.ReadLine()
+            if ($null -ne $line) {
+                $lastOutput = $line
+                $allOutput += $line
+                Write-ConfiguratorLog -Message $line -Level Debug
+            }
+        }
+
+        while (-not $process.StandardError.EndOfStream) {
+            $dirtyError = $process.StandardError.ReadLine()
+            if ($null -ne $dirtyError) {
+                $cleanError = $dirtyError -replace "$([char]27)\[91m", '' -replace "$([char]27)\[31;1m", '' -replace "$([char]27)\[0m", ''
+                $errors += $cleanError
+                Write-ConfiguratorLog -Message $cleanError -Level Debug
+            }
+        }
+    }
+
+    $process.WaitForExit()
+    $exitCode = $process.ExitCode
+    $process.Dispose()
+
+    foreach ($err in $errors) {
+        Write-ConfiguratorLog -Message $err -Level Error
+    }
+
+    if ($exitCode -ne 0) {
+        throw "Script failed to complete with exit code $exitCode"
+    }
+
+    if ($null -ne $ResultType) {
+        if ($null -eq $lastOutput) {
+            return $null
+        }
+
+        if ($ResultType -eq [string]) {
+            return $lastOutput
+        }
+        elseif ($ResultType -eq [bool]) {
+            return [bool]::Parse($lastOutput)
+        }
+        else {
+            throw "PowerShell result type of '$($ResultType.FullName)' is not yet supported"
+        }
+    }
 }

--- a/configurator-pwsh/src/Private/PowerShell/New-ScriptFile.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/New-ScriptFile.ps1
@@ -5,6 +5,14 @@ function New-ScriptFile {
         [string]$Script
     )
 
-    # TODO: Implement - write script to $env:LOCALAPPDATA\Configurator\temp\<timestamp>.ps1, return path
-    throw "Not implemented"
+    $tempDir = Join-Path $env:LOCALAPPDATA 'Configurator' 'temp'
+    New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+    $timestamp = Get-Date -Format 'yyyy-MM-dd_HH-mm-ss-fffff'
+    $fileName = "$timestamp.ps1"
+    $filePath = Join-Path $tempDir $fileName
+
+    Set-Content -Path $filePath -Value $Script -Encoding UTF8
+
+    $filePath
 }

--- a/configurator-pwsh/src/Private/PowerShell/New-ScriptFile.ps1
+++ b/configurator-pwsh/src/Private/PowerShell/New-ScriptFile.ps1
@@ -1,0 +1,10 @@
+function New-ScriptFile {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Script
+    )
+
+    # TODO: Implement - write script to $env:LOCALAPPDATA\Configurator\temp\<timestamp>.ps1, return path
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Registry/Get-RegistryValue.ps1
+++ b/configurator-pwsh/src/Private/Registry/Get-RegistryValue.ps1
@@ -1,0 +1,13 @@
+function Get-RegistryValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$KeyName,
+
+        [Parameter(Mandatory)]
+        [string]$ValueName
+    )
+
+    # TODO: Implement - read registry value, convert int to uint / long to ulong, return as string
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Registry/Get-RegistryValue.ps1
+++ b/configurator-pwsh/src/Private/Registry/Get-RegistryValue.ps1
@@ -8,6 +8,15 @@ function Get-RegistryValue {
         [string]$ValueName
     )
 
-    # TODO: Implement - read registry value, convert int to uint / long to ulong, return as string
-    throw "Not implemented"
+    $value = [Microsoft.Win32.Registry]::GetValue($KeyName, $ValueName, '')
+
+    if ($value -is [int]) {
+        $value = [System.BitConverter]::ToUInt32([System.BitConverter]::GetBytes($value), 0)
+    }
+
+    if ($value -is [long]) {
+        $value = [System.BitConverter]::ToUInt64([System.BitConverter]::GetBytes($value), 0)
+    }
+
+    $value.ToString()
 }

--- a/configurator-pwsh/src/Private/Registry/Set-RegistryValue.ps1
+++ b/configurator-pwsh/src/Private/Registry/Set-RegistryValue.ps1
@@ -1,0 +1,16 @@
+function Set-RegistryValue {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$KeyName,
+
+        [Parameter(Mandatory)]
+        [string]$ValueName,
+
+        [Parameter(Mandatory)]
+        $ValueData
+    )
+
+    # TODO: Implement - determine RegistryValueKind from value type (string -> String, uint -> DWord), write via Set-ItemProperty
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Registry/Set-RegistryValue.ps1
+++ b/configurator-pwsh/src/Private/Registry/Set-RegistryValue.ps1
@@ -11,6 +11,24 @@ function Set-RegistryValue {
         $ValueData
     )
 
-    # TODO: Implement - determine RegistryValueKind from value type (string -> String, uint -> DWord), write via Set-ItemProperty
-    throw "Not implemented"
+    if ($ValueData -is [uint32] -or $ValueData -is [int]) {
+        $registryValueKind = [Microsoft.Win32.RegistryValueKind]::DWord
+        if ($ValueData -is [uint32]) {
+            $ValueData = [int][uint32]$ValueData
+        }
+    }
+    elseif ($ValueData -is [string]) {
+        $registryValueKind = [Microsoft.Win32.RegistryValueKind]::String
+    }
+    else {
+        throw "RegistrySetting.ValueData only supports types: string and uint32"
+    }
+
+    try {
+        [Microsoft.Win32.Registry]::SetValue($KeyName, $ValueName, $ValueData, $registryValueKind)
+    }
+    catch {
+        Write-ConfiguratorLog -Message "Error setting value in registry >> keyName: $KeyName; valueName: $ValueName; RegistryValueKind: $registryValueKind`n$_" -Level Error
+        throw
+    }
 }

--- a/configurator-pwsh/src/Private/Settings/Export-Settings.ps1
+++ b/configurator-pwsh/src/Private/Settings/Export-Settings.ps1
@@ -1,0 +1,10 @@
+function Export-Settings {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject]$Settings
+    )
+
+    # TODO: Implement - serialize settings to JSON, write to settings file, ensure downloads dir exists
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Settings/Export-Settings.ps1
+++ b/configurator-pwsh/src/Private/Settings/Export-Settings.ps1
@@ -5,6 +5,11 @@ function Export-Settings {
         [PSCustomObject]$Settings
     )
 
-    # TODO: Implement - serialize settings to JSON, write to settings file, ensure downloads dir exists
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $settingsPath = Get-SettingsPath
+    $json = $Settings | ConvertTo-Json -Depth 10
+    Set-Content -Path $settingsPath -Value $json -Encoding UTF8
+
+    New-Item -Path $Settings.downloadsDirectory -ItemType Directory -Force | Out-Null
 }

--- a/configurator-pwsh/src/Private/Settings/Get-SettingsPath.ps1
+++ b/configurator-pwsh/src/Private/Settings/Get-SettingsPath.ps1
@@ -1,0 +1,7 @@
+function Get-SettingsPath {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - return "$env:LOCALAPPDATA\Configurator\settings.json"
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Settings/Get-SettingsPath.ps1
+++ b/configurator-pwsh/src/Private/Settings/Get-SettingsPath.ps1
@@ -2,6 +2,7 @@ function Get-SettingsPath {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - return "$env:LOCALAPPDATA\Configurator\settings.json"
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    Join-Path $env:LOCALAPPDATA 'Configurator' 'settings.json'
 }

--- a/configurator-pwsh/src/Private/Settings/Import-Settings.ps1
+++ b/configurator-pwsh/src/Private/Settings/Import-Settings.ps1
@@ -1,0 +1,7 @@
+function Import-Settings {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - load settings.json from LocalAppData, create with defaults if missing, ensure downloads dir exists
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Settings/Import-Settings.ps1
+++ b/configurator-pwsh/src/Private/Settings/Import-Settings.ps1
@@ -2,6 +2,37 @@ function Import-Settings {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - load settings.json from LocalAppData, create with defaults if missing, ensure downloads dir exists
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $settingsPath = Get-SettingsPath
+
+    if (-not (Test-Path $settingsPath)) {
+        $settingsDir = Split-Path $settingsPath -Parent
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+
+        $defaults = [PSCustomObject]@{
+            downloadsDirectory = 'C:/tmp/configurator-downloads'
+            manifest           = [PSCustomObject]@{
+                repo      = $null
+                fileName  = 'manifest.json'
+                directory = $null
+            }
+            git                = [PSCustomObject]@{
+                cloneDirectory = 'C:\src\'
+            }
+        }
+
+        $json = $defaults | ConvertTo-Json -Depth 10
+        Set-Content -Path $settingsPath -Value $json -Encoding UTF8
+
+        New-Item -Path $defaults.downloadsDirectory -ItemType Directory -Force | Out-Null
+
+        return $defaults
+    }
+
+    $settings = Get-Content -Path $settingsPath -Raw | ConvertFrom-Json
+
+    New-Item -Path $settings.downloadsDirectory -ItemType Directory -Force | Out-Null
+
+    $settings
 }

--- a/configurator-pwsh/src/Private/Utilities/Get-Download.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Get-Download.ps1
@@ -1,0 +1,16 @@
+function Get-Download {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Url,
+
+        [Parameter(Mandatory)]
+        [string]$FileName,
+
+        [Parameter(Mandatory)]
+        [string]$DownloadsDirectory
+    )
+
+    # TODO: Implement - HTTP GET url, check status 200, write to downloads dir, return full path
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Utilities/Get-Download.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Get-Download.ps1
@@ -11,6 +11,13 @@ function Get-Download {
         [string]$DownloadsDirectory
     )
 
-    # TODO: Implement - HTTP GET url, check status 200, write to downloads dir, return full path
-    throw "Not implemented"
+    $filePath = Join-Path $DownloadsDirectory $FileName
+
+    $response = Invoke-WebRequest -Uri $Url -OutFile $filePath -PassThru
+
+    if ($response.StatusCode -ne 200) {
+        throw "Failed with status code $($response.StatusCode) to download $FileName"
+    }
+
+    $filePath
 }

--- a/configurator-pwsh/src/Private/Utilities/Remove-DesktopShortcuts.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Remove-DesktopShortcuts.ps1
@@ -1,13 +1,42 @@
+function Get-DesktopEntries {
+    [CmdletBinding()]
+    param()
+
+    $desktopPaths = @(
+        [System.Environment]::GetFolderPath('Desktop')
+        [System.Environment]::GetFolderPath('CommonDesktopDirectory')
+    )
+
+    $entries = @()
+    foreach ($path in $desktopPaths) {
+        if (Test-Path $path) {
+            $entries += Get-ChildItem -Path $path -Force | Select-Object -ExpandProperty FullName
+        }
+    }
+
+    $entries | Select-Object -Unique
+}
+
 function Remove-DesktopShortcuts {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)]
-        [string[]]$PreInstallEntries,
+        [AllowEmptyCollection()]
+        [string[]]$BeforeEntries,
 
         [Parameter(Mandatory)]
-        [string[]]$PostInstallEntries
+        [AllowEmptyCollection()]
+        [string[]]$AfterEntries
     )
 
-    # TODO: Implement - compute diff between pre and post entries, delete new files/directories
-    throw "Not implemented"
+    $newEntries = $AfterEntries | Where-Object { $_ -notin $BeforeEntries }
+
+    foreach ($entry in $newEntries) {
+        if (Test-Path $entry -PathType Leaf) {
+            Remove-Item -Path $entry -Force
+        }
+        elseif (Test-Path $entry -PathType Container) {
+            Remove-Item -Path $entry -Force
+        }
+    }
 }

--- a/configurator-pwsh/src/Private/Utilities/Remove-DesktopShortcuts.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Remove-DesktopShortcuts.ps1
@@ -1,0 +1,13 @@
+function Remove-DesktopShortcuts {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string[]]$PreInstallEntries,
+
+        [Parameter(Mandatory)]
+        [string[]]$PostInstallEntries
+    )
+
+    # TODO: Implement - compute diff between pre and post entries, delete new files/directories
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Utilities/Resolve-Token.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Resolve-Token.ps1
@@ -1,0 +1,10 @@
+function Resolve-Token {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    # TODO: Implement - replace {{source:name}} patterns (e.g. {{env:ProgramFiles}}) with resolved values
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Utilities/Resolve-Token.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Resolve-Token.ps1
@@ -5,6 +5,26 @@ function Resolve-Token {
         [string]$Value
     )
 
-    # TODO: Implement - replace {{source:name}} patterns (e.g. {{env:ProgramFiles}}) with resolved values
-    throw "Not implemented"
+    $pattern = '(\{\{(.*?)\}\})+'
+    $result = $Value
+
+    [regex]::Matches($Value, $pattern) | ForEach-Object {
+        $raw = $_.Value
+        $inner = $raw.TrimStart('{').TrimEnd('}')
+        $parts = $inner.Split(':', [System.StringSplitOptions]::RemoveEmptyEntries)
+        $source = $parts[0]
+        $name = $parts[1]
+
+        $replacement = ''
+        if ($source -eq 'env') {
+            $envValue = [System.Environment]::GetEnvironmentVariable($name)
+            if ($null -ne $envValue) {
+                $replacement = $envValue
+            }
+        }
+
+        $result = $result.Replace($raw, $replacement)
+    }
+
+    $result
 }

--- a/configurator-pwsh/src/Private/Utilities/Test-Administrator.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Test-Administrator.ps1
@@ -2,6 +2,7 @@ function Test-Administrator {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - check if current user is running as Administrator via WindowsPrincipal
-    throw "Not implemented"
+    ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+        [Security.Principal.WindowsBuiltInRole]::Administrator
+    )
 }

--- a/configurator-pwsh/src/Private/Utilities/Test-Administrator.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Test-Administrator.ps1
@@ -1,0 +1,7 @@
+function Test-Administrator {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - check if current user is running as Administrator via WindowsPrincipal
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Utilities/Write-ConfiguratorLog.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Write-ConfiguratorLog.ps1
@@ -1,0 +1,14 @@
+function Write-ConfiguratorLog {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Message,
+
+        [Parameter()]
+        [ValidateSet('Debug', 'Verbose', 'Info', 'Warn', 'Error', 'Progress', 'Result')]
+        [string]$Level = 'Info'
+    )
+
+    # TODO: Implement - format as "[<ISO8601>] [<LEVEL>] <message>" with appropriate console color
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Private/Utilities/Write-ConfiguratorLog.ps1
+++ b/configurator-pwsh/src/Private/Utilities/Write-ConfiguratorLog.ps1
@@ -9,6 +9,30 @@ function Write-ConfiguratorLog {
         [string]$Level = 'Info'
     )
 
-    # TODO: Implement - format as "[<ISO8601>] [<LEVEL>] <message>" with appropriate console color
-    throw "Not implemented"
+    $labelMap = @{
+        Debug    = 'DEBUG'
+        Verbose  = 'INFOV'
+        Info     = 'INFO '
+        Warn     = 'WARN '
+        Error    = 'ERROR'
+        Progress = 'PRGRS'
+        Result   = 'RESLT'
+    }
+
+    $colorMap = @{
+        Debug    = 'Gray'
+        Verbose  = 'White'
+        Info     = 'White'
+        Warn     = 'Yellow'
+        Error    = 'Red'
+        Progress = 'Blue'
+        Result   = 'Green'
+    }
+
+    $timestamp = Get-Date -Format 'o'
+    $label = $labelMap[$Level]
+    $color = $colorMap[$Level]
+
+    $logMessage = "[$timestamp] [$label] $Message"
+    Write-Host $logMessage -ForegroundColor $color
 }

--- a/configurator-pwsh/src/Public/Add-ConfiguratorApp.ps1
+++ b/configurator-pwsh/src/Public/Add-ConfiguratorApp.ps1
@@ -1,0 +1,16 @@
+function Add-ConfiguratorApp {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$AppId,
+
+        [Parameter(Mandatory)]
+        [string]$AppType,
+
+        [Parameter(Mandatory)]
+        [string[]]$Environments
+    )
+
+    # TODO: Implement - create installable, call Save-AppDefinition (idempotent add to manifest + write app.json)
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Add-ConfiguratorApp.ps1
+++ b/configurator-pwsh/src/Public/Add-ConfiguratorApp.ps1
@@ -5,12 +5,18 @@ function Add-ConfiguratorApp {
         [string]$AppId,
 
         [Parameter(Mandatory)]
+        [ValidateSet(
+            'winget', 'scoop', 'scoopBucket', 'powerShell', 'powerShellModule',
+            'powerShellAppPackage', 'script', 'gitRepo', 'gitconfig',
+            'nonPackageApp', 'visualStudioExtension'
+        )]
         [string]$AppType,
 
         [Parameter(Mandatory)]
         [string[]]$Environments
     )
 
-    # TODO: Implement - create installable, call Save-AppDefinition (idempotent add to manifest + write app.json)
-    throw "Not implemented"
+    $joinedEnvironments = $Environments -join '|'
+
+    Save-AppDefinition -AppId $AppId -AppType $AppType -Environments $joinedEnvironments
 }

--- a/configurator-pwsh/src/Public/Get-ConfiguratorSettings.ps1
+++ b/configurator-pwsh/src/Public/Get-ConfiguratorSettings.ps1
@@ -2,6 +2,52 @@ function Get-ConfiguratorSettings {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - load settings, walk property tree, output as table (Name, Value, Type)
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $settings = Import-Settings
+
+    $rows = Get-SettingRows -Node $settings -Prefix ''
+
+    $rows | Format-Table -Property Name, Value, Type -AutoSize
+}
+
+function Get-SettingRows {
+    param(
+        [PSCustomObject]$Node,
+        [string]$Prefix
+    )
+
+    $uriSettings = @('downloadsdirectory', 'manifest.repo', 'git.clonedirectory')
+
+    $rows = @()
+
+    foreach ($prop in $Node.PSObject.Properties) {
+        $path = if ($Prefix -eq '') { $prop.Name.ToLower() } else { "$Prefix.$($prop.Name.ToLower())" }
+        $val = $prop.Value
+
+        if ($null -ne $val -and $val -is [PSCustomObject]) {
+            $rows += Get-SettingRows -Node $val -Prefix $path
+        }
+        else {
+            $typeName = if ($uriSettings -contains $path) {
+                'Uri'
+            }
+            elseif ($val -is [uri]) {
+                'Uri'
+            }
+            else {
+                'String'
+            }
+
+            $displayValue = if ($null -eq $val) { '' } else { $val.ToString() }
+
+            $rows += [PSCustomObject]@{
+                Name  = $path
+                Value = $displayValue
+                Type  = $typeName
+            }
+        }
+    }
+
+    $rows
 }

--- a/configurator-pwsh/src/Public/Get-ConfiguratorSettings.ps1
+++ b/configurator-pwsh/src/Public/Get-ConfiguratorSettings.ps1
@@ -1,0 +1,7 @@
+function Get-ConfiguratorSettings {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - load settings, walk property tree, output as table (Name, Value, Type)
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Invoke-Backup.ps1
+++ b/configurator-pwsh/src/Public/Invoke-Backup.ps1
@@ -2,6 +2,9 @@ function Invoke-Backup {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - load full manifest (no env filter), call Invoke-AppConfigurator -Backup for each app
-    throw "Not implemented"
+    $manifest = Import-Manifest -Environments @()
+
+    foreach ($app in $manifest.Apps) {
+        Invoke-AppConfigurator -App $app -Backup
+    }
 }

--- a/configurator-pwsh/src/Public/Invoke-Backup.ps1
+++ b/configurator-pwsh/src/Public/Invoke-Backup.ps1
@@ -1,0 +1,7 @@
+function Invoke-Backup {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - load full manifest (no env filter), call Invoke-AppConfigurator -Backup for each app
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Invoke-ConfigureMachine.ps1
+++ b/configurator-pwsh/src/Public/Invoke-ConfigureMachine.ps1
@@ -8,6 +8,21 @@ function Invoke-ConfigureMachine {
         [string]$SingleAppId
     )
 
-    # TODO: Implement - load manifest (filtered by environments or single app), install/upgrade each app, configure each app
-    throw "Not implemented"
+    if (-not [string]::IsNullOrWhiteSpace($SingleAppId)) {
+        $manifest = Import-Manifest -SingleAppId $SingleAppId
+    }
+    else {
+        $manifest = Import-Manifest -Environments $Environments
+    }
+
+    foreach ($app in $manifest.Apps) {
+        if ($app.IsDownloadApp) {
+            Install-DownloadApp -App $app
+        }
+        else {
+            Install-App -App $app
+        }
+
+        Invoke-AppConfigurator -App $app -Configure
+    }
 }

--- a/configurator-pwsh/src/Public/Invoke-ConfigureMachine.ps1
+++ b/configurator-pwsh/src/Public/Invoke-ConfigureMachine.ps1
@@ -1,0 +1,13 @@
+function Invoke-ConfigureMachine {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string[]]$Environments = @(),
+
+        [Parameter()]
+        [string]$SingleAppId
+    )
+
+    # TODO: Implement - load manifest (filtered by environments or single app), install/upgrade each app, configure each app
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Invoke-Initialize.ps1
+++ b/configurator-pwsh/src/Public/Invoke-Initialize.ps1
@@ -1,0 +1,7 @@
+function Invoke-Initialize {
+    [CmdletBinding()]
+    param()
+
+    # TODO: Implement - run SystemInitializer, load settings, clone manifest repo, create manifest file if missing
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Invoke-Initialize.ps1
+++ b/configurator-pwsh/src/Public/Invoke-Initialize.ps1
@@ -2,6 +2,45 @@ function Invoke-Initialize {
     [CmdletBinding()]
     param()
 
-    # TODO: Implement - run SystemInitializer, load settings, clone manifest repo, create manifest file if missing
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    Initialize-System
+
+    $settings = Import-Settings
+
+    if ($null -eq $settings.manifest.repo -or $settings.manifest.repo -eq '') {
+        throw "The 'manifest.repo' setting must be set before invoking initialize."
+    }
+
+    $repoUrl = $settings.manifest.repo.ToString()
+    $repoName = $repoUrl.Split('/')[-1].Replace('.git', '')
+    $cloneDir = $settings.git.cloneDirectory.ToString()
+    $manifestDirectory = Join-Path $cloneDir $repoName
+
+    if ($settings.manifest.directory -ne $manifestDirectory) {
+        $settings.manifest.directory = $manifestDirectory
+        Export-Settings -Settings $settings
+    }
+
+    if (-not (Test-Path $manifestDirectory)) {
+        Invoke-PowerShellScript -Script @"
+Push-Location $cloneDir
+git clone $repoUrl
+Pop-Location
+"@
+    }
+
+    $manifestFilePath = Join-Path $manifestDirectory $settings.manifest.fileName
+
+    if (-not (Test-Path $manifestFilePath)) {
+        Set-Content -Path $manifestFilePath -Value '{ }' -Encoding UTF8
+
+        Invoke-PowerShellScript -Script @"
+Push-Location $manifestDirectory
+git add .
+git commit -m '[Configurator] Create manifest file'
+git push
+Pop-Location
+"@
+    }
 }

--- a/configurator-pwsh/src/Public/Set-ConfiguratorSetting.ps1
+++ b/configurator-pwsh/src/Public/Set-ConfiguratorSetting.ps1
@@ -8,6 +8,48 @@ function Set-ConfiguratorSetting {
         [string]$Value
     )
 
-    # TODO: Implement - load settings, find property by dotted path, convert value, set property, save
-    throw "Not implemented"
+    $ErrorActionPreference = 'Stop'
+
+    $settings = Import-Settings
+
+    if (-not (Find-AndSetSetting -SettingPath $Name -SettingValue $Value -ParentNode $settings -ParentPrefix '')) {
+        throw "$Name is not a recognized setting name."
+    }
+
+    Export-Settings -Settings $settings
+}
+
+function Find-AndSetSetting {
+    param(
+        [string]$SettingPath,
+        [string]$SettingValue,
+        [PSCustomObject]$ParentNode,
+        [string]$ParentPrefix
+    )
+
+    $uriSettings = @('downloadsdirectory', 'manifest.repo', 'git.clonedirectory')
+
+    foreach ($prop in $ParentNode.PSObject.Properties) {
+        $path = if ($ParentPrefix -eq '') { $prop.Name.ToLower() } else { "$ParentPrefix.$($prop.Name.ToLower())" }
+        $val = $prop.Value
+
+        if ($null -ne $val -and $val -is [PSCustomObject]) {
+            if (Find-AndSetSetting -SettingPath $SettingPath -SettingValue $SettingValue -ParentNode $val -ParentPrefix $path) {
+                return $true
+            }
+        }
+        else {
+            if ($path -eq $SettingPath.ToLower()) {
+                if ($uriSettings -contains $path) {
+                    $ParentNode.$($prop.Name) = [uri]$SettingValue
+                }
+                else {
+                    $ParentNode.$($prop.Name) = $SettingValue
+                }
+                return $true
+            }
+        }
+    }
+
+    return $false
 }

--- a/configurator-pwsh/src/Public/Set-ConfiguratorSetting.ps1
+++ b/configurator-pwsh/src/Public/Set-ConfiguratorSetting.ps1
@@ -1,0 +1,13 @@
+function Set-ConfiguratorSetting {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [string]$Value
+    )
+
+    # TODO: Implement - load settings, find property by dotted path, convert value, set property, save
+    throw "Not implemented"
+}

--- a/configurator-pwsh/src/Public/Start-Configurator.ps1
+++ b/configurator-pwsh/src/Public/Start-Configurator.ps1
@@ -1,0 +1,158 @@
+function Start-Configurator {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Command,
+
+        [Parameter()]
+        [string[]]$RemainingArgs
+    )
+
+    if (-not (Test-Administrator)) {
+        Write-ConfiguratorLog -Message 'Configurator Cli must be run with elevated privileges.' -Level Error
+        return 2
+    }
+
+    if ([string]::IsNullOrWhiteSpace($Command)) {
+        Show-ConfiguratorHelp
+        return 0
+    }
+
+    try {
+        switch ($Command.ToLower()) {
+            'initialize' {
+                Invoke-Initialize
+                return 0
+            }
+
+            { $_ -in 'configure-machine', 'configure' } {
+                $envString = Get-NamedArgValue -ArgList $RemainingArgs -Names @('--environments', '-e')
+                $singleApp = Get-NamedArgValue -ArgList $RemainingArgs -Names @('--single-app-id', '-app')
+
+                $envList = @()
+                if (-not [string]::IsNullOrWhiteSpace($envString)) {
+                    $envList = $envString.Split('|', [System.StringSplitOptions]::RemoveEmptyEntries)
+                }
+
+                $params = @{
+                    Environments = $envList
+                }
+                if (-not [string]::IsNullOrWhiteSpace($singleApp)) {
+                    $params['SingleAppId'] = $singleApp
+                }
+
+                Invoke-ConfigureMachine @params
+                return 0
+            }
+
+            'settings' {
+                if ($null -eq $RemainingArgs -or $RemainingArgs.Count -eq 0) {
+                    Show-ConfiguratorHelp
+                    return 1
+                }
+
+                $subCommand = $RemainingArgs[0].ToLower()
+
+                switch ($subCommand) {
+                    'list' {
+                        Get-ConfiguratorSettings
+                        return 0
+                    }
+                    'set' {
+                        if ($RemainingArgs.Count -lt 3) {
+                            Write-ConfiguratorLog -Message 'Usage: settings set <setting-name> <setting-value>' -Level Error
+                            return 1
+                        }
+                        Set-ConfiguratorSetting -Name $RemainingArgs[1] -Value $RemainingArgs[2]
+                        return 0
+                    }
+                    default {
+                        Write-ConfiguratorLog -Message "Unknown settings subcommand: $subCommand" -Level Error
+                        return 1
+                    }
+                }
+            }
+
+            { $_ -in 'add-app', 'add' } {
+                $appId = Get-NamedArgValue -ArgList $RemainingArgs -Names @('--app-id')
+                $appType = Get-NamedArgValue -ArgList $RemainingArgs -Names @('--app-type')
+                $envString = Get-NamedArgValue -ArgList $RemainingArgs -Names @('--environments')
+
+                if ([string]::IsNullOrWhiteSpace($appId) -or [string]::IsNullOrWhiteSpace($appType) -or [string]::IsNullOrWhiteSpace($envString)) {
+                    Write-ConfiguratorLog -Message 'Usage: add-app --app-id <id> --app-type <type> --environments <envs>' -Level Error
+                    return 1
+                }
+
+                $envList = $envString.Split('|', [System.StringSplitOptions]::RemoveEmptyEntries)
+
+                Add-ConfiguratorApp -AppId $appId -AppType $appType -Environments $envList
+                return 0
+            }
+
+            'backup' {
+                Invoke-Backup
+                return 0
+            }
+
+            default {
+                Write-ConfiguratorLog -Message "Unknown command: $Command" -Level Error
+                return 1
+            }
+        }
+    }
+    catch {
+        Write-ConfiguratorLog -Message $_.Exception.Message -Level Error
+        return 1
+    }
+}
+
+function Show-ConfiguratorHelp {
+    [CmdletBinding()]
+    param()
+
+    $helpText = @"
+Configurator
+
+Usage:
+  Configurator.ps1 <command> [options]
+
+Commands:
+  initialize                     Runs system initialization and clones the manifest repo in settings.
+  configure-machine, configure   Runs all apps of the manifest repo in settings.
+  settings list                  List all settings with values.
+  settings set <name> <value>    Set single named setting.
+  add-app, add                   Add app for use on the next machine.
+  backup                         Backup app configurations etc. for use on the next machine.
+
+Options for configure-machine:
+  --environments, -e <envs>      Pipe-separated list of environments to target.
+  --single-app-id, -app <id>     The single app to install by Id.
+
+Options for add-app:
+  --app-id <id>                  Id of the app.
+  --app-type <type>              Specifies the installer to use.
+  --environments <envs>          Pipe-separated environment list.
+"@
+    Write-Host $helpText
+}
+
+function Get-NamedArgValue {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [AllowNull()]
+        [string[]]$ArgList,
+
+        [Parameter(Mandatory)]
+        [string[]]$Names
+    )
+
+    if ($null -eq $ArgList) { return $null }
+
+    for ($i = 0; $i -lt $ArgList.Count; $i++) {
+        if ($Names -contains $ArgList[$i] -and ($i + 1) -lt $ArgList.Count) {
+            return $ArgList[$i + 1]
+        }
+    }
+    return $null
+}

--- a/configurator-pwsh/tests/Configurator.Tests.ps1
+++ b/configurator-pwsh/tests/Configurator.Tests.ps1
@@ -1,0 +1,27 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Configurator Module' {
+    It 'imports without errors' {
+        $module = Get-Module -Name 'Configurator'
+        $module | Should -Not -BeNullOrEmpty
+    }
+
+    It 'exports expected public functions' {
+        $expectedFunctions = @(
+            'Invoke-Initialize'
+            'Invoke-ConfigureMachine'
+            'Get-ConfiguratorSettings'
+            'Set-ConfiguratorSetting'
+            'Add-ConfiguratorApp'
+            'Invoke-Backup'
+        )
+
+        $module = Get-Module -Name 'Configurator'
+        foreach ($fn in $expectedFunctions) {
+            $module.ExportedFunctions.Keys | Should -Contain $fn
+        }
+    }
+}

--- a/configurator-pwsh/tests/Configurator.Tests.ps1
+++ b/configurator-pwsh/tests/Configurator.Tests.ps1
@@ -17,6 +17,7 @@ Describe 'Configurator Module' {
             'Set-ConfiguratorSetting'
             'Add-ConfiguratorApp'
             'Invoke-Backup'
+            'Start-Configurator'
         )
 
         $module = Get-Module -Name 'Configurator'

--- a/configurator-pwsh/tests/Integration/ManifestRepository.Integration.Tests.ps1
+++ b/configurator-pwsh/tests/Integration/ManifestRepository.Integration.Tests.ps1
@@ -1,0 +1,731 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+
+    $script:testManifestsDir = Join-Path $PSScriptRoot 'TestManifests'
+}
+
+Describe 'Save-AppDefinition Integration' {
+    It 'saves an installable to a new manifest' {
+        InModuleScope Configurator {
+            $tempDir = Join-Path $TestDrive 'save-new'
+            New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $tempDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            $appId = 'test-save-new-app'
+            Save-AppDefinition -AppId $appId -AppType 'winget' -Environments 'Test'
+
+            $manifest = Import-Manifest
+
+            @($manifest.AppIds).Count | Should -Be 1
+            $manifest.AppIds[0] | Should -Be $appId
+            @($manifest.Apps).Count | Should -Be 1
+            $manifest.Apps[0].AppId | Should -Be $appId
+            $manifest.Apps[0].AppType | Should -Be 'winget'
+        }
+    }
+
+    It 'saves an installable to an existing manifest' {
+        InModuleScope Configurator {
+            $tempDir = Join-Path $TestDrive 'save-existing'
+            New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $tempDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            $appId1 = 'test-existing-app-1'
+            Save-AppDefinition -AppId $appId1 -AppType 'winget' -Environments 'Test'
+
+            $appId2 = 'test-existing-app-2'
+            Save-AppDefinition -AppId $appId2 -AppType 'script' -Environments 'Test'
+
+            $manifest = Import-Manifest
+
+            @($manifest.AppIds).Count | Should -Be 2
+            $manifest.AppIds[0] | Should -Be $appId1
+            $manifest.AppIds[1] | Should -Be $appId2
+            $manifest.Apps[0].AppId | Should -Be $appId1
+            $manifest.Apps[0].AppType | Should -Be 'winget'
+            $manifest.Apps[1].AppId | Should -Be $appId2
+            $manifest.Apps[1].AppType | Should -Be 'script'
+        }
+    }
+
+    It 'does not duplicate when saving the same app twice' {
+        InModuleScope Configurator {
+            $tempDir = Join-Path $TestDrive 'save-idempotent'
+            New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $tempDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            $appId = 'test-idempotent-app'
+            Save-AppDefinition -AppId $appId -AppType 'winget' -Environments 'Test'
+            Save-AppDefinition -AppId $appId -AppType 'script' -Environments 'Other'
+
+            $manifest = Import-Manifest
+
+            @($manifest.AppIds).Count | Should -Be 1
+            $manifest.AppIds[0] | Should -Be $appId
+            @($manifest.Apps).Count | Should -Be 1
+            $manifest.Apps[0].AppType | Should -Be 'winget'
+        }
+    }
+}
+
+Describe 'Import-Manifest Integration - Single App' {
+    It 'loads a single app by ID' {
+        InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'multiple-apps.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            $manifest = Import-Manifest -SingleAppId 'environment-1-and-3-app-id-3'
+
+            @($manifest.Apps).Count | Should -Be 1
+            $manifest.Apps[0].AppId | Should -Be 'environment-1-and-3-app-id-3'
+        } -ArgumentList $script:testManifestsDir
+    }
+}
+
+Describe 'Import-Manifest Integration - Winget Apps' {
+    BeforeAll {
+        $script:wingetManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'winget.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic winget app' {
+        $app = $script:wingetManifest.Apps[0]
+        $app.AppId | Should -Be 'winget-app-id'
+        $app.AppType | Should -Be 'winget'
+        $app.InstallArgs | Should -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeFalse
+        $app.Configuration | Should -BeNullOrEmpty
+    }
+
+    It 'loads winget app with install args' {
+        $app = $script:wingetManifest.Apps[1]
+        $app.AppId | Should -Be 'winget-app-id-with-install-args'
+        $app.InstallArgs | Should -Be ' --override install-args'
+    }
+
+    It 'loads winget app with prevent upgrade' {
+        $app = $script:wingetManifest.Apps[2]
+        $app.AppId | Should -Be 'winget-app-id-with-prevent-upgrade'
+        $app.PreventUpgrade | Should -BeTrue
+    }
+
+    It 'loads winget app with configuration' {
+        $app = $script:wingetManifest.Apps[3]
+        $app.AppId | Should -Be 'winget-app-id-with-configuration'
+        $app.Configuration | Should -Not -BeNullOrEmpty
+        $app.Configuration.registrySettings.Count | Should -Be 1
+        $app.Configuration.registrySettings[0].keyName | Should -Be 'key-name-test'
+        $app.Configuration.registrySettings[0].valueName | Should -Be 'value-name-test'
+        $app.Configuration.registrySettings[0].valueData | Should -Be 'value-data-test'
+    }
+}
+
+Describe 'Import-Manifest Integration - Scoop Apps' {
+    BeforeAll {
+        $script:scoopManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'scoop.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic scoop app' {
+        $app = $script:scoopManifest.Apps[0]
+        $app.AppId | Should -Be 'scoop-app-id'
+        $app.AppType | Should -Be 'scoop'
+        $app.InstallArgs | Should -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeFalse
+        $app.Configuration | Should -BeNullOrEmpty
+    }
+
+    It 'loads scoop app with install args' {
+        $app = $script:scoopManifest.Apps[1]
+        $app.AppId | Should -Be 'scoop-app-id-with-install-args'
+        $app.InstallArgs | Should -Be ' install-args'
+    }
+
+    It 'loads scoop app with prevent upgrade' {
+        $app = $script:scoopManifest.Apps[2]
+        $app.AppId | Should -Be 'scoop-app-id-with-prevent-upgrade'
+        $app.PreventUpgrade | Should -BeTrue
+    }
+
+    It 'loads scoop app with configuration' {
+        $app = $script:scoopManifest.Apps[3]
+        $app.AppId | Should -Be 'scoop-app-id-with-configuration'
+        $app.Configuration | Should -Not -BeNullOrEmpty
+        $app.Configuration.registrySettings.Count | Should -Be 1
+        $app.Configuration.registrySettings[0].keyName | Should -Be 'key-name-test'
+        $app.Configuration.registrySettings[0].valueName | Should -Be 'value-name-test'
+        $app.Configuration.registrySettings[0].valueData | Should -Be 'value-data-test'
+    }
+}
+
+Describe 'Import-Manifest Integration - Scoop Bucket Apps' {
+    It 'loads basic scoop bucket app' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'scoop-bucket.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 1
+        $manifest.Apps[0].AppId | Should -Be 'scoop-bucket-app-id'
+        $manifest.Apps[0].AppType | Should -Be 'scoopBucket'
+    }
+}
+
+Describe 'Import-Manifest Integration - Script Apps' {
+    BeforeAll {
+        $script:scriptManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'script.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic script app' {
+        $app = $script:scriptManifest.Apps[0]
+        $app.AppId | Should -Be 'script-app-id'
+        $app.AppType | Should -Be 'script'
+        $app.InstallScript | Should -Be 'install-script'
+        $app.VerificationScript | Should -Be 'verification-script'
+        $app.UpgradeScript | Should -Be 'upgrade-script'
+        $app.Configuration | Should -BeNullOrEmpty
+    }
+
+    It 'loads script app with configuration' {
+        $app = $script:scriptManifest.Apps[1]
+        $app.AppId | Should -Be 'script-app-id-with-configuration'
+        $app.Configuration | Should -Not -BeNullOrEmpty
+        $app.Configuration.registrySettings.Count | Should -Be 1
+        $app.Configuration.registrySettings[0].keyName | Should -Be 'key-name-test'
+        $app.Configuration.registrySettings[0].valueName | Should -Be 'value-name-test'
+        $app.Configuration.registrySettings[0].valueData | Should -Be 'value-data-test'
+    }
+}
+
+Describe 'Import-Manifest Integration - PowerShell Apps' {
+    BeforeAll {
+        $script:psManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'powershell.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic PowerShell app with all scripts' {
+        $app = $script:psManifest.Apps | Where-Object { $_.AppId -eq 'powershell-app-id-1' }
+        $app | Should -Not -BeNullOrEmpty
+        $app.AppType | Should -Be 'powerShell'
+
+        $expectedInstall = Join-Path $script:testManifestsDir 'apps' 'powershell-app-id-1' 'install.ps1'
+        $app.InstallScript | Should -Be ". `"$expectedInstall`""
+
+        $expectedUpgrade = Join-Path $script:testManifestsDir 'apps' 'powershell-app-id-1' 'upgrade.ps1'
+        $app.UpgradeScript | Should -Be ". `"$expectedUpgrade`""
+
+        $expectedVerification = Join-Path $script:testManifestsDir 'apps' 'powershell-app-id-1' 'verification.ps1'
+        $app.VerificationScript | Should -Be ". `"$expectedVerification`""
+
+        $app.InstallArgs | Should -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeFalse
+        $app.Configuration | Should -BeNullOrEmpty
+    }
+
+    It 'loads PowerShell app with null non-install scripts when files missing' {
+        $app = $script:psManifest.Apps | Where-Object { $_.AppId -eq 'powershell-app-id-2' }
+        $app | Should -Not -BeNullOrEmpty
+        $app.InstallScript | Should -Not -BeNullOrEmpty
+        $app.UpgradeScript | Should -BeNullOrEmpty
+        $app.VerificationScript | Should -BeNullOrEmpty
+    }
+
+    It 'does not load PowerShell app with missing install script' {
+        $app = $script:psManifest.Apps | Where-Object { $_.AppId -eq 'powershell-app-id-3' }
+        $app | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Import-Manifest Integration - PowerShell Module Apps' {
+    BeforeAll {
+        $script:psModuleManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'power-shell-module.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic PowerShell module app' {
+        $app = $script:psModuleManifest.Apps[0]
+        $app.AppId | Should -Be 'power-shell-module-app-id'
+        $app.AppType | Should -Be 'powerShellModule'
+        $app.InstallArgs | Should -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeFalse
+        $app.Configuration | Should -BeNullOrEmpty
+    }
+
+    It 'loads PowerShell module app with install args' {
+        $app = $script:psModuleManifest.Apps[1]
+        $app.AppId | Should -Be 'power-shell-module-app-id-with-install-args'
+        $app.InstallArgs | Should -Be ' install-args'
+    }
+
+    It 'loads PowerShell module app with prevent upgrade' {
+        $app = $script:psModuleManifest.Apps[2]
+        $app.AppId | Should -Be 'power-shell-module-app-id-with-prevent-upgrade'
+        $app.PreventUpgrade | Should -BeTrue
+    }
+
+    It 'loads PowerShell module app with configuration' {
+        $app = $script:psModuleManifest.Apps[3]
+        $app.AppId | Should -Be 'power-shell-module-app-id-with-configuration'
+        $app.Configuration | Should -Not -BeNullOrEmpty
+        $app.Configuration.registrySettings.Count | Should -Be 1
+        $app.Configuration.registrySettings[0].keyName | Should -Be 'key-name-test'
+        $app.Configuration.registrySettings[0].valueName | Should -Be 'value-name-test'
+        $app.Configuration.registrySettings[0].valueData | Should -Be 'value-data-test'
+    }
+}
+
+Describe 'Import-Manifest Integration - PowerShell App Package Apps' {
+    BeforeAll {
+        $script:psAppPkgManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'power-shell-app-packages.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic PowerShell app package' {
+        $app = $script:psAppPkgManifest.Apps[0]
+        $app.AppId | Should -Be 'power-shell-app-package-app-id'
+        $app.AppType | Should -Be 'powerShellAppPackage'
+        $app.Downloader | Should -Be 'some-downloader'
+        $app.DownloaderArgs | Should -Not -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeFalse
+        $app.IsDownloadApp | Should -BeTrue
+    }
+
+    It 'loads PowerShell app package with prevent upgrade' {
+        $app = $script:psAppPkgManifest.Apps[1]
+        $app.AppId | Should -Be 'power-shell-app-package-app-id-with-prevent-upgrade'
+        $app.Downloader | Should -Be 'some-downloader'
+        $app.DownloaderArgs | Should -Not -BeNullOrEmpty
+        $app.PreventUpgrade | Should -BeTrue
+    }
+}
+
+Describe 'Import-Manifest Integration - Gitconfig Apps' {
+    It 'loads basic gitconfig app' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'gitconfig.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 1
+        $manifest.Apps[0].AppId | Should -Be 'gitconfig-app-id'
+        $manifest.Apps[0].AppType | Should -Be 'gitconfig'
+    }
+}
+
+Describe 'Import-Manifest Integration - Git Repo Apps' {
+    BeforeAll {
+        $script:gitRepoManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'git-repo.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads basic git repo app and excludes misconfigured ones' {
+        @($script:gitRepoManifest.Apps).Count | Should -Be 1
+        $app = $script:gitRepoManifest.Apps[0]
+        $app.AppId | Should -Be 'git-repo-app-id'
+        $app.AppType | Should -Be 'gitRepo'
+        $app.InstallArgs | Should -Be 'https://organization/repo.git'
+        $app.PreventUpgrade | Should -BeTrue
+        $app.InstallScript | Should -BeLike '*C:\src\*'
+        $app.InstallScript | Should -BeLike '*https://organization/repo.git*'
+        $app.UpgradeScript | Should -BeLike '*C:\src\repo*'
+        $app.VerificationScript | Should -BeLike '*C:\src\repo*'
+    }
+}
+
+Describe 'Import-Manifest Integration - Non-Package Apps' {
+    It 'loads basic non-package app' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'non-package.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 1
+        $manifest.Apps[0].AppId | Should -Be 'non-package-app-id'
+        $manifest.Apps[0].AppType | Should -Be 'nonPackageApp'
+    }
+}
+
+Describe 'Import-Manifest Integration - Visual Studio Extension Apps' {
+    It 'loads basic visual studio extension app' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'visual-studio-extension.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 1
+        $app = $manifest.Apps[0]
+        $app.AppId | Should -Be 'visual-studio-extension-app-id'
+        $app.AppType | Should -Be 'visualStudioExtension'
+        $app.IsDownloadApp | Should -BeTrue
+        $app.Downloader | Should -Be 'VisualStudioMarketplaceDownloader'
+        $app.DownloaderArgs.publisher | Should -Be 'publisher-1'
+        $app.DownloaderArgs.extensionName | Should -Be 'extension-name-1'
+    }
+}
+
+Describe 'Import-Manifest Integration - Unknown Apps' {
+    It 'does not load unknown app types' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'unknown.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 0
+    }
+}
+
+Describe 'Import-Manifest Integration - Registry Settings' {
+    BeforeAll {
+        $script:regManifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'registry-settings.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+    }
+
+    It 'loads string registry setting value data' {
+        $regSettings = $script:regManifest.Apps[0].Configuration.registrySettings
+        $regSettings[0].keyName | Should -Be 'key-1'
+        $regSettings[0].valueName | Should -Be 'string'
+        $regSettings[0].valueData | Should -Be 'string-data'
+    }
+
+    It 'loads string registry setting with environment token' {
+        $regSettings = $script:regManifest.Apps[0].Configuration.registrySettings
+        $regSettings[1].keyName | Should -Be 'key-2'
+        $regSettings[1].valueName | Should -Be 'string'
+        $regSettings[1].valueData | Should -Be '{{env:ProgramFiles}}\string-data'
+    }
+
+    It 'loads integer registry setting value data' {
+        $regSettings = $script:regManifest.Apps[0].Configuration.registrySettings
+        $regSettings[2].keyName | Should -Be 'key-3'
+        $regSettings[2].valueName | Should -Be 'uint'
+        $regSettings[2].valueData | Should -Be 42
+    }
+}
+
+Describe 'Import-Manifest Integration - Environment Filtering' {
+    It 'loads all apps when no environments specified' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'multiple-apps.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 5
+    }
+
+    It 'loads apps for a specific environment, ignoring case' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'multiple-apps.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest -Environments @('environment2')
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 1
+    }
+
+    It 'loads apps for multiple environments' {
+        $manifest = InModuleScope Configurator {
+            param($testManifestsDir)
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $testManifestsDir
+                        fileName  = 'multiple-apps.manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Import-Manifest -Environments @('Environment2', 'Environment3')
+        } -ArgumentList $script:testManifestsDir
+
+        @($manifest.Apps).Count | Should -Be 3
+    }
+}
+
+Describe 'Add-ConfiguratorApp Integration' {
+    It 'saves and loads a new app through the public command' {
+        InModuleScope Configurator {
+            $tempDir = Join-Path $TestDrive 'add-app-integration'
+            New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $tempDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            Add-ConfiguratorApp -AppId 'integration-test-app' -AppType 'winget' -Environments @('Work', 'Personal')
+
+            $manifest = Import-Manifest
+
+            @($manifest.Apps).Count | Should -Be 1
+            $manifest.Apps[0].AppId | Should -Be 'integration-test-app'
+            $manifest.Apps[0].AppType | Should -Be 'winget'
+        }
+    }
+}

--- a/configurator-pwsh/tests/Integration/Settings.Integration.Tests.ps1
+++ b/configurator-pwsh/tests/Integration/Settings.Integration.Tests.ps1
@@ -1,0 +1,50 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Settings Integration - Load Before Save' {
+    It 'returns sensible defaults on first load' {
+        InModuleScope Configurator {
+            $settingsDir = Join-Path $TestDrive 'settings-first-load'
+            $settingsPath = Join-Path $settingsDir 'settings.json'
+
+            Mock Get-SettingsPath { return $settingsPath }
+
+            $settings = Import-Settings
+
+            $settings | Should -Not -BeNullOrEmpty
+            $settings.downloadsDirectory | Should -Be 'C:/tmp/configurator-downloads'
+            $settings.manifest.fileName | Should -Be 'manifest.json'
+            $settings.manifest.repo | Should -BeNullOrEmpty
+            $settings.manifest.directory | Should -BeNullOrEmpty
+            $settings.git.cloneDirectory | Should -Be 'C:\src\'
+
+            Test-Path $settingsPath | Should -BeTrue
+        }
+    }
+}
+
+Describe 'Settings Integration - Load After Save' {
+    It 'returns saved settings after export' {
+        InModuleScope Configurator {
+            $settingsDir = Join-Path $TestDrive 'settings-save-load'
+            New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+            $settingsPath = Join-Path $settingsDir 'settings.json'
+
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $settings = Import-Settings
+
+            $newFileName = 'custom-manifest.json'
+            $settings.manifest | Add-Member -MemberType NoteProperty -Name 'fileName' -Value $newFileName -Force
+
+            Export-Settings -Settings $settings
+
+            $reloaded = Import-Settings
+
+            $reloaded.manifest.fileName | Should -Be $newFileName
+        }
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-and-3-app-id-3/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-and-3-app-id-3/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "environment-1-and-3-app-id-3",
+    "environments": "Environment1|Environment3"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-app-id-1/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-app-id-1/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "environment-1-app-id-1",
+    "environments": "Environment1"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-app-id-2/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/environment-1-app-id-2/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "environment-1-app-id-2",
+    "environments": "Environment1"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/environment-2-app-id-1/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/environment-2-app-id-1/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "environment-2-app-id-1",
+    "environments": "Environment2"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/environment-3-app-id-1/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/environment-3-app-id-1/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "environment-3-app-id-1",
+    "environments": "Environment3"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id-blank-install-args/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id-blank-install-args/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "gitRepo",
+    "appId": "git-repo-app-id-blank-install-args",
+    "environments": "Test",
+    "installArgs": ""
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id-missing-install-args/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id-missing-install-args/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "gitRepo",
+    "appId": "git-repo-app-id-missing-install-args",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/git-repo-app-id/app.json
@@ -1,0 +1,7 @@
+{
+    "appType": "gitRepo",
+    "appId": "git-repo-app-id",
+    "environments": "Test",
+    "installArgs": "https://organization/repo.git",
+    "preventUpgrade": true
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/gitconfig-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/gitconfig-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "gitconfig",
+    "appId": "gitconfig-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/non-package-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/non-package-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "nonPackageApp",
+    "appId": "non-package-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-app-package-app-id-with-prevent-upgrade/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-app-package-app-id-with-prevent-upgrade/app.json
@@ -1,0 +1,12 @@
+{
+    "appType": "powerShellAppPackage",
+    "appId": "power-shell-app-package-app-id-with-prevent-upgrade",
+    "environments": "Test",
+    "downloader": "some-downloader",
+    "downloaderArgs": {
+        "prop1": "prop-1",
+        "prop2": "prop-2",
+        "prop3": "prop-3"
+    },
+    "preventUpgrade": true
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-app-package-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-app-package-app-id/app.json
@@ -1,0 +1,11 @@
+{
+    "appType": "powerShellAppPackage",
+    "appId": "power-shell-app-package-app-id",
+    "environments": "Test",
+    "downloader": "some-downloader",
+    "downloaderArgs": {
+        "prop1": "prop-1",
+        "prop2": "prop-2",
+        "prop3": "prop-3"
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-configuration/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-configuration/app.json
@@ -1,0 +1,14 @@
+{
+    "appType": "powerShellModule",
+    "appId": "power-shell-module-app-id-with-configuration",
+    "environments": "Test",
+    "configuration": {
+        "registrySettings": [
+            {
+                "keyName": "key-name-test",
+                "valueName": "value-name-test",
+                "valueData": "value-data-test"
+            }
+        ]
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-install-args/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-install-args/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "powerShellModule",
+    "appId": "power-shell-module-app-id-with-install-args",
+    "environments": "Test",
+    "installArgs": "install-args"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-prevent-upgrade/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id-with-prevent-upgrade/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "powerShellModule",
+    "appId": "power-shell-module-app-id-with-prevent-upgrade",
+    "environments": "Test",
+    "preventUpgrade": true
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/power-shell-module-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "powerShellModule",
+    "appId": "power-shell-module-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "powerShell",
+    "appId": "powershell-app-id-1",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/install.ps1
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/install.ps1
@@ -1,0 +1,1 @@
+Write-Output 'install powershell-app-id-1'

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/upgrade.ps1
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/upgrade.ps1
@@ -1,0 +1,1 @@
+Write-Output 'upgrade powershell-app-id-1'

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/verification.ps1
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-1/verification.ps1
@@ -1,0 +1,1 @@
+Write-Output 'verify powershell-app-id-1'

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-2/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-2/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "powerShell",
+    "appId": "powershell-app-id-2",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-2/install.ps1
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-2/install.ps1
@@ -1,0 +1,1 @@
+Write-Output 'install powershell-app-id-2'

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-3/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/powershell-app-id-3/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "powerShell",
+    "appId": "powershell-app-id-3",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/registry-settings-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/registry-settings-app-id/app.json
@@ -1,0 +1,24 @@
+{
+    "appType": "winget",
+    "appId": "registry-settings-app-id",
+    "environments": "Test",
+    "configuration": {
+        "registrySettings": [
+            {
+                "keyName": "key-1",
+                "valueName": "string",
+                "valueData": "string-data"
+            },
+            {
+                "keyName": "key-2",
+                "valueName": "string",
+                "valueData": "{{env:ProgramFiles}}\\string-data"
+            },
+            {
+                "keyName": "key-3",
+                "valueName": "uint",
+                "valueData": 42
+            }
+        ]
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-configuration/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-configuration/app.json
@@ -1,0 +1,14 @@
+{
+    "appType": "scoop",
+    "appId": "scoop-app-id-with-configuration",
+    "environments": "Test",
+    "configuration": {
+        "registrySettings": [
+            {
+                "keyName": "key-name-test",
+                "valueName": "value-name-test",
+                "valueData": "value-data-test"
+            }
+        ]
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-install-args/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-install-args/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "scoop",
+    "appId": "scoop-app-id-with-install-args",
+    "environments": "Test",
+    "installArgs": "install-args"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-prevent-upgrade/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id-with-prevent-upgrade/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "scoop",
+    "appId": "scoop-app-id-with-prevent-upgrade",
+    "environments": "Test",
+    "preventUpgrade": true
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "scoop",
+    "appId": "scoop-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-bucket-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/scoop-bucket-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "scoopBucket",
+    "appId": "scoop-bucket-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/script-app-id-with-configuration/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/script-app-id-with-configuration/app.json
@@ -1,0 +1,14 @@
+{
+    "appType": "script",
+    "appId": "script-app-id-with-configuration",
+    "environments": "Test",
+    "configuration": {
+        "registrySettings": [
+            {
+                "keyName": "key-name-test",
+                "valueName": "value-name-test",
+                "valueData": "value-data-test"
+            }
+        ]
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/script-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/script-app-id/app.json
@@ -1,0 +1,8 @@
+{
+    "appType": "script",
+    "appId": "script-app-id",
+    "environments": "Test",
+    "installScript": "install-script",
+    "verificationScript": "verification-script",
+    "upgradeScript": "upgrade-script"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/unknown-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/unknown-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "unknown",
+    "appId": "unknown-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/visual-studio-extension-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/visual-studio-extension-app-id/app.json
@@ -1,0 +1,9 @@
+{
+    "appType": "visualStudioExtension",
+    "appId": "visual-studio-extension-app-id",
+    "environments": "Test",
+    "downloaderArgs": {
+        "publisher": "publisher-1",
+        "extensionName": "extension-name-1"
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-configuration/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-configuration/app.json
@@ -1,0 +1,14 @@
+{
+    "appType": "winget",
+    "appId": "winget-app-id-with-configuration",
+    "environments": "Test",
+    "configuration": {
+        "registrySettings": [
+            {
+                "keyName": "key-name-test",
+                "valueName": "value-name-test",
+                "valueData": "value-data-test"
+            }
+        ]
+    }
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-install-args/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-install-args/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "winget",
+    "appId": "winget-app-id-with-install-args",
+    "environments": "Test",
+    "installArgs": "install-args"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-prevent-upgrade/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id-with-prevent-upgrade/app.json
@@ -1,0 +1,6 @@
+{
+    "appType": "winget",
+    "appId": "winget-app-id-with-prevent-upgrade",
+    "environments": "Test",
+    "preventUpgrade": true
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id/app.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/apps/winget-app-id/app.json
@@ -1,0 +1,5 @@
+{
+    "appType": "winget",
+    "appId": "winget-app-id",
+    "environments": "Test"
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/git-repo.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/git-repo.manifest.json
@@ -1,0 +1,7 @@
+{
+    "apps": [
+        "git-repo-app-id",
+        "git-repo-app-id-missing-install-args",
+        "git-repo-app-id-blank-install-args"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/gitconfig.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/gitconfig.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "gitconfig-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/multiple-apps.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/multiple-apps.manifest.json
@@ -1,0 +1,9 @@
+{
+    "apps": [
+        "environment-1-app-id-1",
+        "environment-1-app-id-2",
+        "environment-1-and-3-app-id-3",
+        "environment-2-app-id-1",
+        "environment-3-app-id-1"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/non-package.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/non-package.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "non-package-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/power-shell-app-packages.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/power-shell-app-packages.manifest.json
@@ -1,0 +1,6 @@
+{
+    "apps": [
+        "power-shell-app-package-app-id",
+        "power-shell-app-package-app-id-with-prevent-upgrade"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/power-shell-module.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/power-shell-module.manifest.json
@@ -1,0 +1,8 @@
+{
+    "apps": [
+        "power-shell-module-app-id",
+        "power-shell-module-app-id-with-install-args",
+        "power-shell-module-app-id-with-prevent-upgrade",
+        "power-shell-module-app-id-with-configuration"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/powershell.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/powershell.manifest.json
@@ -1,0 +1,7 @@
+{
+    "apps": [
+        "powershell-app-id-1",
+        "powershell-app-id-2",
+        "powershell-app-id-3"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/registry-settings.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/registry-settings.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "registry-settings-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/scoop-bucket.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/scoop-bucket.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "scoop-bucket-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/scoop.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/scoop.manifest.json
@@ -1,0 +1,8 @@
+{
+    "apps": [
+        "scoop-app-id",
+        "scoop-app-id-with-install-args",
+        "scoop-app-id-with-prevent-upgrade",
+        "scoop-app-id-with-configuration"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/script.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/script.manifest.json
@@ -1,0 +1,6 @@
+{
+    "apps": [
+        "script-app-id",
+        "script-app-id-with-configuration"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/unknown.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/unknown.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "unknown-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/visual-studio-extension.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/visual-studio-extension.manifest.json
@@ -1,0 +1,5 @@
+{
+    "apps": [
+        "visual-studio-extension-app-id"
+    ]
+}

--- a/configurator-pwsh/tests/Integration/TestManifests/winget.manifest.json
+++ b/configurator-pwsh/tests/Integration/TestManifests/winget.manifest.json
@@ -1,0 +1,8 @@
+{
+    "apps": [
+        "winget-app-id",
+        "winget-app-id-with-install-args",
+        "winget-app-id-with-prevent-upgrade",
+        "winget-app-id-with-configuration"
+    ]
+}

--- a/configurator-pwsh/tests/Unit/Private/AppTypes.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/AppTypes.Tests.ps1
@@ -1,0 +1,431 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'New-WingetApp' {
+    It 'creates app with correct scripts' {
+        $raw = [PSCustomObject]@{
+            appType        = 'winget'
+            appId          = 'Microsoft.VisualStudioCode'
+            environments   = 'Work|Personal'
+            installArgs    = $null
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-WingetApp -RawApp $raw
+
+        $result.AppId | Should -Be 'Microsoft.VisualStudioCode'
+        $result.AppType | Should -Be 'winget'
+        $result.InstallScript | Should -Be 'winget install --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
+        $result.VerificationScript | Should -Be '(winget list --id Microsoft.VisualStudioCode -e | Select-String Microsoft.VisualStudioCode) -ne $null'
+        $result.UpgradeScript | Should -Be 'winget upgrade --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
+        $result.PreventUpgrade | Should -BeFalse
+        $result.IsDownloadApp | Should -BeFalse
+    }
+
+    It 'transforms installArgs with --override prefix' {
+        $raw = [PSCustomObject]@{
+            appType        = 'winget'
+            appId          = 'Some.App'
+            environments   = 'Work'
+            installArgs    = 'install-args'
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-WingetApp -RawApp $raw
+
+        $result.InstallArgs | Should -Be ' --override install-args'
+        $result.InstallScript | Should -BeLike '* --override install-args'
+    }
+
+    It 'preserves preventUpgrade flag' {
+        $raw = [PSCustomObject]@{
+            appType        = 'winget'
+            appId          = 'Some.App'
+            environments   = 'Work'
+            installArgs    = $null
+            preventUpgrade = $true
+            configuration  = $null
+        }
+
+        $result = New-WingetApp -RawApp $raw
+
+        $result.PreventUpgrade | Should -BeTrue
+    }
+
+    It 'preserves configuration' {
+        $config = [PSCustomObject]@{
+            registrySettings = @(
+                [PSCustomObject]@{
+                    keyName   = 'HKCU\Test'
+                    valueName = 'Setting'
+                    valueData = 'Value'
+                }
+            )
+        }
+
+        $raw = [PSCustomObject]@{
+            appType        = 'winget'
+            appId          = 'Some.App'
+            environments   = 'Work'
+            installArgs    = $null
+            preventUpgrade = $false
+            configuration  = $config
+        }
+
+        $result = New-WingetApp -RawApp $raw
+
+        $result.Configuration | Should -Not -BeNullOrEmpty
+        $result.Configuration.registrySettings.Count | Should -Be 1
+    }
+}
+
+Describe 'New-ScoopApp' {
+    It 'creates app with correct scripts' {
+        $raw = [PSCustomObject]@{
+            appType        = 'scoop'
+            appId          = '7zip'
+            environments   = 'Personal'
+            installArgs    = $null
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-ScoopApp -RawApp $raw
+
+        $result.AppId | Should -Be '7zip'
+        $result.InstallScript | Should -Be 'scoop install 7zip'
+        $result.VerificationScript | Should -Be '(scoop export | Select-String 7zip) -ne $null'
+        $result.UpgradeScript | Should -Be 'scoop update 7zip'
+    }
+
+    It 'prepends space to installArgs' {
+        $raw = [PSCustomObject]@{
+            appType        = 'scoop'
+            appId          = '7zip'
+            environments   = 'Personal'
+            installArgs    = 'install-args'
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-ScoopApp -RawApp $raw
+
+        $result.InstallArgs | Should -Be ' install-args'
+        $result.InstallScript | Should -Be 'scoop install 7zip install-args'
+    }
+}
+
+Describe 'New-ScoopBucketApp' {
+    It 'creates app with correct scripts and fixed verification' {
+        $raw = [PSCustomObject]@{
+            appType      = 'scoopBucket'
+            appId        = 'extras'
+            environments = 'Personal'
+        }
+
+        $result = New-ScoopBucketApp -RawApp $raw
+
+        $result.AppId | Should -Be 'extras'
+        $result.InstallScript | Should -Be 'scoop bucket add extras'
+        $result.VerificationScript | Should -BeLike "*(scoop bucket list | Select-String 'extras')*"
+        $result.UpgradeScript | Should -BeNullOrEmpty
+        $result.PreventUpgrade | Should -BeFalse
+        $result.Configuration | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'New-PowerShellApp' {
+    It 'loads scripts from files' {
+        $manifestDir = Join-Path $TestDrive 'ps-manifest'
+        $appDir = Join-Path $manifestDir 'apps' 'my-ps-app'
+        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+
+        Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
+        Set-Content -Path (Join-Path $appDir 'upgrade.ps1') -Value 'Write-Host upgrade'
+        Set-Content -Path (Join-Path $appDir 'verification.ps1') -Value 'Write-Host verify'
+
+        $raw = [PSCustomObject]@{
+            appType      = 'powerShell'
+            appId        = 'my-ps-app'
+            environments = 'Work'
+        }
+
+        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+        $result.AppId | Should -Be 'my-ps-app'
+        $result.InstallScript | Should -BeLike '. "*install.ps1"'
+        $result.UpgradeScript | Should -BeLike '. "*upgrade.ps1"'
+        $result.VerificationScript | Should -BeLike '. "*verification.ps1"'
+    }
+
+    It 'returns null when install.ps1 is missing' {
+        $manifestDir = Join-Path $TestDrive 'ps-manifest-missing'
+        $appDir = Join-Path $manifestDir 'apps' 'no-install-app'
+        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+
+        $raw = [PSCustomObject]@{
+            appType      = 'powerShell'
+            appId        = 'no-install-app'
+            environments = 'Work'
+        }
+
+        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'sets upgrade and verification to null when files missing' {
+        $manifestDir = Join-Path $TestDrive 'ps-manifest-partial'
+        $appDir = Join-Path $manifestDir 'apps' 'partial-app'
+        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+        Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
+
+        $raw = [PSCustomObject]@{
+            appType      = 'powerShell'
+            appId        = 'partial-app'
+            environments = 'Work'
+        }
+
+        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+        $result | Should -Not -BeNullOrEmpty
+        $result.UpgradeScript | Should -BeNullOrEmpty
+        $result.VerificationScript | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'New-PowerShellModuleApp' {
+    It 'creates app with correct multi-line scripts' {
+        $raw = [PSCustomObject]@{
+            appType        = 'powerShellModule'
+            appId          = 'posh-git'
+            environments   = 'Work'
+            installArgs    = $null
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-PowerShellModuleApp -RawApp $raw
+
+        $result.InstallScript | Should -BeLike 'Import-Module PowerShellGet*Install-Module*posh-git'
+        $result.VerificationScript | Should -Be '(Get-Module -ListAvailable posh-git) -ne $null'
+        $result.UpgradeScript | Should -BeLike 'Import-Module PowerShellGet*Update-Module*posh-git'
+    }
+
+    It 'prepends space to installArgs' {
+        $raw = [PSCustomObject]@{
+            appType        = 'powerShellModule'
+            appId          = 'posh-git'
+            environments   = 'Work'
+            installArgs    = '-Force -AllowClobber'
+            preventUpgrade = $false
+            configuration  = $null
+        }
+
+        $result = New-PowerShellModuleApp -RawApp $raw
+
+        $result.InstallArgs | Should -Be ' -Force -AllowClobber'
+    }
+}
+
+Describe 'New-PowerShellAppPackageApp' {
+    It 'creates download app with correct scripts' {
+        $raw = [PSCustomObject]@{
+            appType        = 'powerShellAppPackage'
+            appId          = 'Microsoft.DesktopAppInstaller'
+            environments   = 'Work'
+            preventUpgrade = $false
+            downloader     = 'GitHubAssetDownloader'
+            downloaderArgs = [PSCustomObject]@{
+                User      = 'microsoft'
+                Repo      = 'winget-cli'
+                Extension = '.msixbundle'
+            }
+        }
+
+        $result = New-PowerShellAppPackageApp -RawApp $raw
+
+        $result.IsDownloadApp | Should -BeTrue
+        $result.Downloader | Should -Be 'GitHubAssetDownloader'
+        $result.InstallScript | Should -BeLike 'Import-Module appx*Add-AppPackage*'
+        $result.VerificationScript | Should -BeLike 'Import-Module appx*Get-AppPackage*Microsoft.DesktopAppInstaller*'
+        $result.UpgradeScript | Should -Be $result.InstallScript
+    }
+}
+
+Describe 'New-ScriptApp' {
+    It 'uses inline scripts from JSON fields' {
+        $raw = [PSCustomObject]@{
+            appType            = 'script'
+            appId              = 'my-script'
+            environments       = 'Work'
+            installScript      = 'Write-Host install'
+            verificationScript = 'Write-Host verify'
+            upgradeScript      = 'Write-Host upgrade'
+            configuration      = $null
+        }
+
+        $result = New-ScriptApp -RawApp $raw
+
+        $result.InstallScript | Should -Be 'Write-Host install'
+        $result.VerificationScript | Should -Be 'Write-Host verify'
+        $result.UpgradeScript | Should -Be 'Write-Host upgrade'
+        $result.PreventUpgrade | Should -BeFalse
+    }
+}
+
+Describe 'New-GitRepoApp' {
+    It 'creates app with git clone/pull scripts' {
+        $raw = [PSCustomObject]@{
+            appType        = 'gitRepo'
+            appId          = 'git.my-project'
+            environments   = 'Work'
+            installArgs    = 'https://github.com/org/repo.git'
+            preventUpgrade = $false
+        }
+
+        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+        $result.InstallScript | Should -BeLike 'mkdir C:\src\*git clone*'
+        $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
+        $result.UpgradeScript | Should -BeLike 'pushd C:\src\repo*git pull*'
+    }
+
+    It 'returns null when installArgs is null' {
+        $raw = [PSCustomObject]@{
+            appType        = 'gitRepo'
+            appId          = 'git.bad'
+            environments   = 'Work'
+            installArgs    = $null
+            preventUpgrade = $false
+        }
+
+        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'returns null when installArgs is whitespace' {
+        $raw = [PSCustomObject]@{
+            appType        = 'gitRepo'
+            appId          = 'git.blank'
+            environments   = 'Work'
+            installArgs    = '   '
+            preventUpgrade = $false
+        }
+
+        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+        $result | Should -BeNullOrEmpty
+    }
+
+    It 'appends trailing backslash to clone directory' {
+        $raw = [PSCustomObject]@{
+            appType        = 'gitRepo'
+            appId          = 'git.test'
+            environments   = 'Work'
+            installArgs    = 'https://github.com/org/repo.git'
+            preventUpgrade = $false
+        }
+
+        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src'
+
+        $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
+    }
+}
+
+Describe 'New-GitconfigApp' {
+    It 'creates app with git config commands' {
+        $raw = [PSCustomObject]@{
+            appType      = 'gitconfig'
+            appId        = 'path/to/.gitconfig-custom'
+            environments = 'Work'
+        }
+
+        $result = New-GitconfigApp -RawApp $raw
+
+        $result.InstallScript | Should -Be 'git config --global --add include.path path/to/.gitconfig-custom'
+        $result.VerificationScript | Should -BeLike '*(git config --get-all --global include.path) -match*'
+        $result.UpgradeScript | Should -BeNullOrEmpty
+    }
+
+    It 'escapes backslashes in verification regex' {
+        $raw = [PSCustomObject]@{
+            appType      = 'gitconfig'
+            appId        = 'path\to\.gitconfig'
+            environments = 'Work'
+        }
+
+        $result = New-GitconfigApp -RawApp $raw
+
+        $result.VerificationScript | Should -BeLike '*path\\to\\.gitconfig*'
+    }
+}
+
+Describe 'New-NonPackageApp' {
+    It 'creates app with convention-based install script' {
+        $raw = [PSCustomObject]@{
+            appType      = 'nonPackageApp'
+            appId        = 'my-custom-thing'
+            environments = 'Work'
+        }
+
+        $result = New-NonPackageApp -RawApp $raw
+
+        $result.InstallScript | Should -Be './my-custom-thing_install.ps1'
+        $result.VerificationScript | Should -BeNullOrEmpty
+        $result.UpgradeScript | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'New-VisualStudioExtensionApp' {
+    It 'creates download app with vsix installer script' {
+        $raw = [PSCustomObject]@{
+            appType        = 'visualStudioExtension'
+            appId          = 'vs-ext-app'
+            environments   = 'Work'
+            preventUpgrade = $false
+            downloaderArgs = [PSCustomObject]@{
+                Publisher     = 'Shanewho'
+                ExtensionName = 'IHateRegions'
+            }
+        }
+
+        $result = New-VisualStudioExtensionApp -RawApp $raw
+
+        $result.IsDownloadApp | Should -BeTrue
+        $result.Downloader | Should -Be 'VisualStudioMarketplaceDownloader'
+        $result.InstallScript | Should -BeLike '*vsixInstaller*'
+        $result.InstallScript | Should -Not -BeLike '*vsi0xInstaller*'
+        $result.VerificationScript | Should -BeNullOrEmpty
+        $result.UpgradeScript | Should -Be $result.InstallScript
+    }
+}
+
+Describe 'New-GitHubAssetApp' {
+    It 'creates internal download app with empty install script' {
+        $raw = [PSCustomObject]@{
+            appType        = 'gitHubAsset'
+            appId          = 'Configurator'
+            environments   = ''
+            downloaderArgs = [PSCustomObject]@{
+                User      = 'dannydwarren'
+                Repo      = 'configurator'
+                Extension = '.exe'
+            }
+        }
+
+        $result = New-GitHubAssetApp -RawApp $raw
+
+        $result.InstallScript | Should -Be ''
+        $result.VerificationScript | Should -BeNullOrEmpty
+        $result.UpgradeScript | Should -BeNullOrEmpty
+        $result.PreventUpgrade | Should -BeTrue
+        $result.IsDownloadApp | Should -BeTrue
+        $result.Downloader | Should -Be 'GitHubAssetDownloader'
+    }
+}

--- a/configurator-pwsh/tests/Unit/Private/AppTypes.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/AppTypes.Tests.ps1
@@ -5,427 +5,473 @@ BeforeAll {
 
 Describe 'New-WingetApp' {
     It 'creates app with correct scripts' {
-        $raw = [PSCustomObject]@{
-            appType        = 'winget'
-            appId          = 'Microsoft.VisualStudioCode'
-            environments   = 'Work|Personal'
-            installArgs    = $null
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'winget'
+                appId          = 'Microsoft.VisualStudioCode'
+                environments   = 'Work|Personal'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-WingetApp -RawApp $raw
+
+            $result.AppId | Should -Be 'Microsoft.VisualStudioCode'
+            $result.AppType | Should -Be 'winget'
+            $result.InstallScript | Should -Be 'winget install --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
+            $result.VerificationScript | Should -Be '(winget list --id Microsoft.VisualStudioCode -e | Select-String Microsoft.VisualStudioCode) -ne $null'
+            $result.UpgradeScript | Should -Be 'winget upgrade --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
+            $result.PreventUpgrade | Should -BeFalse
+            $result.IsDownloadApp | Should -BeFalse
         }
-
-        $result = New-WingetApp -RawApp $raw
-
-        $result.AppId | Should -Be 'Microsoft.VisualStudioCode'
-        $result.AppType | Should -Be 'winget'
-        $result.InstallScript | Should -Be 'winget install --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
-        $result.VerificationScript | Should -Be '(winget list --id Microsoft.VisualStudioCode -e | Select-String Microsoft.VisualStudioCode) -ne $null'
-        $result.UpgradeScript | Should -Be 'winget upgrade --id Microsoft.VisualStudioCode --accept-package-agreements -h -e'
-        $result.PreventUpgrade | Should -BeFalse
-        $result.IsDownloadApp | Should -BeFalse
     }
 
     It 'transforms installArgs with --override prefix' {
-        $raw = [PSCustomObject]@{
-            appType        = 'winget'
-            appId          = 'Some.App'
-            environments   = 'Work'
-            installArgs    = 'install-args'
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'winget'
+                appId          = 'Some.App'
+                environments   = 'Work'
+                installArgs    = 'install-args'
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-WingetApp -RawApp $raw
+
+            $result.InstallArgs | Should -Be ' --override install-args'
+            $result.InstallScript | Should -BeLike '* --override install-args'
         }
-
-        $result = New-WingetApp -RawApp $raw
-
-        $result.InstallArgs | Should -Be ' --override install-args'
-        $result.InstallScript | Should -BeLike '* --override install-args'
     }
 
     It 'preserves preventUpgrade flag' {
-        $raw = [PSCustomObject]@{
-            appType        = 'winget'
-            appId          = 'Some.App'
-            environments   = 'Work'
-            installArgs    = $null
-            preventUpgrade = $true
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'winget'
+                appId          = 'Some.App'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $true
+                configuration  = $null
+            }
+
+            $result = New-WingetApp -RawApp $raw
+
+            $result.PreventUpgrade | Should -BeTrue
         }
-
-        $result = New-WingetApp -RawApp $raw
-
-        $result.PreventUpgrade | Should -BeTrue
     }
 
     It 'preserves configuration' {
-        $config = [PSCustomObject]@{
-            registrySettings = @(
-                [PSCustomObject]@{
-                    keyName   = 'HKCU\Test'
-                    valueName = 'Setting'
-                    valueData = 'Value'
-                }
-            )
+        InModuleScope Configurator {
+            $config = [PSCustomObject]@{
+                registrySettings = @(
+                    [PSCustomObject]@{
+                        keyName   = 'HKCU\Test'
+                        valueName = 'Setting'
+                        valueData = 'Value'
+                    }
+                )
+            }
+
+            $raw = [PSCustomObject]@{
+                appType        = 'winget'
+                appId          = 'Some.App'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $config
+            }
+
+            $result = New-WingetApp -RawApp $raw
+
+            $result.Configuration | Should -Not -BeNullOrEmpty
+            $result.Configuration.registrySettings.Count | Should -Be 1
         }
-
-        $raw = [PSCustomObject]@{
-            appType        = 'winget'
-            appId          = 'Some.App'
-            environments   = 'Work'
-            installArgs    = $null
-            preventUpgrade = $false
-            configuration  = $config
-        }
-
-        $result = New-WingetApp -RawApp $raw
-
-        $result.Configuration | Should -Not -BeNullOrEmpty
-        $result.Configuration.registrySettings.Count | Should -Be 1
     }
 }
 
 Describe 'New-ScoopApp' {
     It 'creates app with correct scripts' {
-        $raw = [PSCustomObject]@{
-            appType        = 'scoop'
-            appId          = '7zip'
-            environments   = 'Personal'
-            installArgs    = $null
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'scoop'
+                appId          = '7zip'
+                environments   = 'Personal'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-ScoopApp -RawApp $raw
+
+            $result.AppId | Should -Be '7zip'
+            $result.InstallScript | Should -Be 'scoop install 7zip'
+            $result.VerificationScript | Should -Be '(scoop export | Select-String 7zip) -ne $null'
+            $result.UpgradeScript | Should -Be 'scoop update 7zip'
         }
-
-        $result = New-ScoopApp -RawApp $raw
-
-        $result.AppId | Should -Be '7zip'
-        $result.InstallScript | Should -Be 'scoop install 7zip'
-        $result.VerificationScript | Should -Be '(scoop export | Select-String 7zip) -ne $null'
-        $result.UpgradeScript | Should -Be 'scoop update 7zip'
     }
 
     It 'prepends space to installArgs' {
-        $raw = [PSCustomObject]@{
-            appType        = 'scoop'
-            appId          = '7zip'
-            environments   = 'Personal'
-            installArgs    = 'install-args'
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'scoop'
+                appId          = '7zip'
+                environments   = 'Personal'
+                installArgs    = 'install-args'
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-ScoopApp -RawApp $raw
+
+            $result.InstallArgs | Should -Be ' install-args'
+            $result.InstallScript | Should -Be 'scoop install 7zip install-args'
         }
-
-        $result = New-ScoopApp -RawApp $raw
-
-        $result.InstallArgs | Should -Be ' install-args'
-        $result.InstallScript | Should -Be 'scoop install 7zip install-args'
     }
 }
 
 Describe 'New-ScoopBucketApp' {
     It 'creates app with correct scripts and fixed verification' {
-        $raw = [PSCustomObject]@{
-            appType      = 'scoopBucket'
-            appId        = 'extras'
-            environments = 'Personal'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType      = 'scoopBucket'
+                appId        = 'extras'
+                environments = 'Personal'
+            }
+
+            $result = New-ScoopBucketApp -RawApp $raw
+
+            $result.AppId | Should -Be 'extras'
+            $result.InstallScript | Should -Be 'scoop bucket add extras'
+            $result.VerificationScript | Should -BeLike "*(scoop bucket list | Select-String 'extras')*"
+            $result.UpgradeScript | Should -BeNullOrEmpty
+            $result.PreventUpgrade | Should -BeFalse
+            $result.Configuration | Should -BeNullOrEmpty
         }
-
-        $result = New-ScoopBucketApp -RawApp $raw
-
-        $result.AppId | Should -Be 'extras'
-        $result.InstallScript | Should -Be 'scoop bucket add extras'
-        $result.VerificationScript | Should -BeLike "*(scoop bucket list | Select-String 'extras')*"
-        $result.UpgradeScript | Should -BeNullOrEmpty
-        $result.PreventUpgrade | Should -BeFalse
-        $result.Configuration | Should -BeNullOrEmpty
     }
 }
 
 Describe 'New-PowerShellApp' {
     It 'loads scripts from files' {
-        $manifestDir = Join-Path $TestDrive 'ps-manifest'
-        $appDir = Join-Path $manifestDir 'apps' 'my-ps-app'
-        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'ps-manifest'
+            $appDir = Join-Path $manifestDir 'apps' 'my-ps-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
 
-        Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
-        Set-Content -Path (Join-Path $appDir 'upgrade.ps1') -Value 'Write-Host upgrade'
-        Set-Content -Path (Join-Path $appDir 'verification.ps1') -Value 'Write-Host verify'
+            Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
+            Set-Content -Path (Join-Path $appDir 'upgrade.ps1') -Value 'Write-Host upgrade'
+            Set-Content -Path (Join-Path $appDir 'verification.ps1') -Value 'Write-Host verify'
 
-        $raw = [PSCustomObject]@{
-            appType      = 'powerShell'
-            appId        = 'my-ps-app'
-            environments = 'Work'
+            $raw = [PSCustomObject]@{
+                appType      = 'powerShell'
+                appId        = 'my-ps-app'
+                environments = 'Work'
+            }
+
+            $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+            $result.AppId | Should -Be 'my-ps-app'
+            $result.InstallScript | Should -BeLike '. "*install.ps1"'
+            $result.UpgradeScript | Should -BeLike '. "*upgrade.ps1"'
+            $result.VerificationScript | Should -BeLike '. "*verification.ps1"'
         }
-
-        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
-
-        $result.AppId | Should -Be 'my-ps-app'
-        $result.InstallScript | Should -BeLike '. "*install.ps1"'
-        $result.UpgradeScript | Should -BeLike '. "*upgrade.ps1"'
-        $result.VerificationScript | Should -BeLike '. "*verification.ps1"'
     }
 
     It 'returns null when install.ps1 is missing' {
-        $manifestDir = Join-Path $TestDrive 'ps-manifest-missing'
-        $appDir = Join-Path $manifestDir 'apps' 'no-install-app'
-        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'ps-manifest-missing'
+            $appDir = Join-Path $manifestDir 'apps' 'no-install-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
 
-        $raw = [PSCustomObject]@{
-            appType      = 'powerShell'
-            appId        = 'no-install-app'
-            environments = 'Work'
+            $raw = [PSCustomObject]@{
+                appType      = 'powerShell'
+                appId        = 'no-install-app'
+                environments = 'Work'
+            }
+
+            $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+            $result | Should -BeNullOrEmpty
         }
-
-        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
-
-        $result | Should -BeNullOrEmpty
     }
 
     It 'sets upgrade and verification to null when files missing' {
-        $manifestDir = Join-Path $TestDrive 'ps-manifest-partial'
-        $appDir = Join-Path $manifestDir 'apps' 'partial-app'
-        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
-        Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'ps-manifest-partial'
+            $appDir = Join-Path $manifestDir 'apps' 'partial-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+            Set-Content -Path (Join-Path $appDir 'install.ps1') -Value 'Write-Host install'
 
-        $raw = [PSCustomObject]@{
-            appType      = 'powerShell'
-            appId        = 'partial-app'
-            environments = 'Work'
+            $raw = [PSCustomObject]@{
+                appType      = 'powerShell'
+                appId        = 'partial-app'
+                environments = 'Work'
+            }
+
+            $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.UpgradeScript | Should -BeNullOrEmpty
+            $result.VerificationScript | Should -BeNullOrEmpty
         }
-
-        $result = New-PowerShellApp -RawApp $raw -ManifestDirectory $manifestDir
-
-        $result | Should -Not -BeNullOrEmpty
-        $result.UpgradeScript | Should -BeNullOrEmpty
-        $result.VerificationScript | Should -BeNullOrEmpty
     }
 }
 
 Describe 'New-PowerShellModuleApp' {
     It 'creates app with correct multi-line scripts' {
-        $raw = [PSCustomObject]@{
-            appType        = 'powerShellModule'
-            appId          = 'posh-git'
-            environments   = 'Work'
-            installArgs    = $null
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'powerShellModule'
+                appId          = 'posh-git'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-PowerShellModuleApp -RawApp $raw
+
+            $result.InstallScript | Should -BeLike 'Import-Module PowerShellGet*Install-Module*posh-git'
+            $result.VerificationScript | Should -Be '(Get-Module -ListAvailable posh-git) -ne $null'
+            $result.UpgradeScript | Should -BeLike 'Import-Module PowerShellGet*Update-Module*posh-git'
         }
-
-        $result = New-PowerShellModuleApp -RawApp $raw
-
-        $result.InstallScript | Should -BeLike 'Import-Module PowerShellGet*Install-Module*posh-git'
-        $result.VerificationScript | Should -Be '(Get-Module -ListAvailable posh-git) -ne $null'
-        $result.UpgradeScript | Should -BeLike 'Import-Module PowerShellGet*Update-Module*posh-git'
     }
 
     It 'prepends space to installArgs' {
-        $raw = [PSCustomObject]@{
-            appType        = 'powerShellModule'
-            appId          = 'posh-git'
-            environments   = 'Work'
-            installArgs    = '-Force -AllowClobber'
-            preventUpgrade = $false
-            configuration  = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'powerShellModule'
+                appId          = 'posh-git'
+                environments   = 'Work'
+                installArgs    = '-Force -AllowClobber'
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = New-PowerShellModuleApp -RawApp $raw
+
+            $result.InstallArgs | Should -Be ' -Force -AllowClobber'
         }
-
-        $result = New-PowerShellModuleApp -RawApp $raw
-
-        $result.InstallArgs | Should -Be ' -Force -AllowClobber'
     }
 }
 
 Describe 'New-PowerShellAppPackageApp' {
     It 'creates download app with correct scripts' {
-        $raw = [PSCustomObject]@{
-            appType        = 'powerShellAppPackage'
-            appId          = 'Microsoft.DesktopAppInstaller'
-            environments   = 'Work'
-            preventUpgrade = $false
-            downloader     = 'GitHubAssetDownloader'
-            downloaderArgs = [PSCustomObject]@{
-                User      = 'microsoft'
-                Repo      = 'winget-cli'
-                Extension = '.msixbundle'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'powerShellAppPackage'
+                appId          = 'Microsoft.DesktopAppInstaller'
+                environments   = 'Work'
+                preventUpgrade = $false
+                downloader     = 'GitHubAssetDownloader'
+                downloaderArgs = [PSCustomObject]@{
+                    User      = 'microsoft'
+                    Repo      = 'winget-cli'
+                    Extension = '.msixbundle'
+                }
             }
+
+            $result = New-PowerShellAppPackageApp -RawApp $raw
+
+            $result.IsDownloadApp | Should -BeTrue
+            $result.Downloader | Should -Be 'GitHubAssetDownloader'
+            $result.InstallScript | Should -BeLike 'Import-Module appx*Add-AppPackage*'
+            $result.VerificationScript | Should -BeLike 'Import-Module appx*Get-AppPackage*Microsoft.DesktopAppInstaller*'
+            $result.UpgradeScript | Should -Be $result.InstallScript
         }
-
-        $result = New-PowerShellAppPackageApp -RawApp $raw
-
-        $result.IsDownloadApp | Should -BeTrue
-        $result.Downloader | Should -Be 'GitHubAssetDownloader'
-        $result.InstallScript | Should -BeLike 'Import-Module appx*Add-AppPackage*'
-        $result.VerificationScript | Should -BeLike 'Import-Module appx*Get-AppPackage*Microsoft.DesktopAppInstaller*'
-        $result.UpgradeScript | Should -Be $result.InstallScript
     }
 }
 
 Describe 'New-ScriptApp' {
     It 'uses inline scripts from JSON fields' {
-        $raw = [PSCustomObject]@{
-            appType            = 'script'
-            appId              = 'my-script'
-            environments       = 'Work'
-            installScript      = 'Write-Host install'
-            verificationScript = 'Write-Host verify'
-            upgradeScript      = 'Write-Host upgrade'
-            configuration      = $null
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType            = 'script'
+                appId              = 'my-script'
+                environments       = 'Work'
+                installScript      = 'Write-Host install'
+                verificationScript = 'Write-Host verify'
+                upgradeScript      = 'Write-Host upgrade'
+                configuration      = $null
+            }
+
+            $result = New-ScriptApp -RawApp $raw
+
+            $result.InstallScript | Should -Be 'Write-Host install'
+            $result.VerificationScript | Should -Be 'Write-Host verify'
+            $result.UpgradeScript | Should -Be 'Write-Host upgrade'
+            $result.PreventUpgrade | Should -BeFalse
         }
-
-        $result = New-ScriptApp -RawApp $raw
-
-        $result.InstallScript | Should -Be 'Write-Host install'
-        $result.VerificationScript | Should -Be 'Write-Host verify'
-        $result.UpgradeScript | Should -Be 'Write-Host upgrade'
-        $result.PreventUpgrade | Should -BeFalse
     }
 }
 
 Describe 'New-GitRepoApp' {
     It 'creates app with git clone/pull scripts' {
-        $raw = [PSCustomObject]@{
-            appType        = 'gitRepo'
-            appId          = 'git.my-project'
-            environments   = 'Work'
-            installArgs    = 'https://github.com/org/repo.git'
-            preventUpgrade = $false
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'gitRepo'
+                appId          = 'git.my-project'
+                environments   = 'Work'
+                installArgs    = 'https://github.com/org/repo.git'
+                preventUpgrade = $false
+            }
+
+            $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+            $result.InstallScript | Should -BeLike 'mkdir C:\src\*git clone*'
+            $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
+            $result.UpgradeScript | Should -BeLike 'pushd C:\src\repo*git pull*'
         }
-
-        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
-
-        $result.InstallScript | Should -BeLike 'mkdir C:\src\*git clone*'
-        $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
-        $result.UpgradeScript | Should -BeLike 'pushd C:\src\repo*git pull*'
     }
 
     It 'returns null when installArgs is null' {
-        $raw = [PSCustomObject]@{
-            appType        = 'gitRepo'
-            appId          = 'git.bad'
-            environments   = 'Work'
-            installArgs    = $null
-            preventUpgrade = $false
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'gitRepo'
+                appId          = 'git.bad'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $false
+            }
+
+            $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+            $result | Should -BeNullOrEmpty
         }
-
-        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
-
-        $result | Should -BeNullOrEmpty
     }
 
     It 'returns null when installArgs is whitespace' {
-        $raw = [PSCustomObject]@{
-            appType        = 'gitRepo'
-            appId          = 'git.blank'
-            environments   = 'Work'
-            installArgs    = '   '
-            preventUpgrade = $false
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'gitRepo'
+                appId          = 'git.blank'
+                environments   = 'Work'
+                installArgs    = '   '
+                preventUpgrade = $false
+            }
+
+            $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
+
+            $result | Should -BeNullOrEmpty
         }
-
-        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src\'
-
-        $result | Should -BeNullOrEmpty
     }
 
     It 'appends trailing backslash to clone directory' {
-        $raw = [PSCustomObject]@{
-            appType        = 'gitRepo'
-            appId          = 'git.test'
-            environments   = 'Work'
-            installArgs    = 'https://github.com/org/repo.git'
-            preventUpgrade = $false
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'gitRepo'
+                appId          = 'git.test'
+                environments   = 'Work'
+                installArgs    = 'https://github.com/org/repo.git'
+                preventUpgrade = $false
+            }
+
+            $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src'
+
+            $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
         }
-
-        $result = New-GitRepoApp -RawApp $raw -CloneRootDirectory 'C:\src'
-
-        $result.VerificationScript | Should -Be 'Test-Path C:\src\repo'
     }
 }
 
 Describe 'New-GitconfigApp' {
     It 'creates app with git config commands' {
-        $raw = [PSCustomObject]@{
-            appType      = 'gitconfig'
-            appId        = 'path/to/.gitconfig-custom'
-            environments = 'Work'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType      = 'gitconfig'
+                appId        = 'path/to/.gitconfig-custom'
+                environments = 'Work'
+            }
+
+            $result = New-GitconfigApp -RawApp $raw
+
+            $result.InstallScript | Should -Be 'git config --global --add include.path path/to/.gitconfig-custom'
+            $result.VerificationScript | Should -BeLike '*(git config --get-all --global include.path) -match*'
+            $result.UpgradeScript | Should -BeNullOrEmpty
         }
-
-        $result = New-GitconfigApp -RawApp $raw
-
-        $result.InstallScript | Should -Be 'git config --global --add include.path path/to/.gitconfig-custom'
-        $result.VerificationScript | Should -BeLike '*(git config --get-all --global include.path) -match*'
-        $result.UpgradeScript | Should -BeNullOrEmpty
     }
 
     It 'escapes backslashes in verification regex' {
-        $raw = [PSCustomObject]@{
-            appType      = 'gitconfig'
-            appId        = 'path\to\.gitconfig'
-            environments = 'Work'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType      = 'gitconfig'
+                appId        = 'path\to\.gitconfig'
+                environments = 'Work'
+            }
+
+            $result = New-GitconfigApp -RawApp $raw
+
+            $result.VerificationScript | Should -BeLike '*path\\to\\.gitconfig*'
         }
-
-        $result = New-GitconfigApp -RawApp $raw
-
-        $result.VerificationScript | Should -BeLike '*path\\to\\.gitconfig*'
     }
 }
 
 Describe 'New-NonPackageApp' {
     It 'creates app with convention-based install script' {
-        $raw = [PSCustomObject]@{
-            appType      = 'nonPackageApp'
-            appId        = 'my-custom-thing'
-            environments = 'Work'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType      = 'nonPackageApp'
+                appId        = 'my-custom-thing'
+                environments = 'Work'
+            }
+
+            $result = New-NonPackageApp -RawApp $raw
+
+            $result.InstallScript | Should -Be './my-custom-thing_install.ps1'
+            $result.VerificationScript | Should -BeNullOrEmpty
+            $result.UpgradeScript | Should -BeNullOrEmpty
         }
-
-        $result = New-NonPackageApp -RawApp $raw
-
-        $result.InstallScript | Should -Be './my-custom-thing_install.ps1'
-        $result.VerificationScript | Should -BeNullOrEmpty
-        $result.UpgradeScript | Should -BeNullOrEmpty
     }
 }
 
 Describe 'New-VisualStudioExtensionApp' {
     It 'creates download app with vsix installer script' {
-        $raw = [PSCustomObject]@{
-            appType        = 'visualStudioExtension'
-            appId          = 'vs-ext-app'
-            environments   = 'Work'
-            preventUpgrade = $false
-            downloaderArgs = [PSCustomObject]@{
-                Publisher     = 'Shanewho'
-                ExtensionName = 'IHateRegions'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'visualStudioExtension'
+                appId          = 'vs-ext-app'
+                environments   = 'Work'
+                preventUpgrade = $false
+                downloaderArgs = [PSCustomObject]@{
+                    Publisher     = 'Shanewho'
+                    ExtensionName = 'IHateRegions'
+                }
             }
+
+            $result = New-VisualStudioExtensionApp -RawApp $raw
+
+            $result.IsDownloadApp | Should -BeTrue
+            $result.Downloader | Should -Be 'VisualStudioMarketplaceDownloader'
+            $result.InstallScript | Should -BeLike '*vsixInstaller*'
+            $result.InstallScript | Should -Not -BeLike '*vsi0xInstaller*'
+            $result.VerificationScript | Should -BeNullOrEmpty
+            $result.UpgradeScript | Should -Be $result.InstallScript
         }
-
-        $result = New-VisualStudioExtensionApp -RawApp $raw
-
-        $result.IsDownloadApp | Should -BeTrue
-        $result.Downloader | Should -Be 'VisualStudioMarketplaceDownloader'
-        $result.InstallScript | Should -BeLike '*vsixInstaller*'
-        $result.InstallScript | Should -Not -BeLike '*vsi0xInstaller*'
-        $result.VerificationScript | Should -BeNullOrEmpty
-        $result.UpgradeScript | Should -Be $result.InstallScript
     }
 }
 
 Describe 'New-GitHubAssetApp' {
     It 'creates internal download app with empty install script' {
-        $raw = [PSCustomObject]@{
-            appType        = 'gitHubAsset'
-            appId          = 'Configurator'
-            environments   = ''
-            downloaderArgs = [PSCustomObject]@{
-                User      = 'dannydwarren'
-                Repo      = 'configurator'
-                Extension = '.exe'
+        InModuleScope Configurator {
+            $raw = [PSCustomObject]@{
+                appType        = 'gitHubAsset'
+                appId          = 'Configurator'
+                environments   = ''
+                downloaderArgs = [PSCustomObject]@{
+                    User      = 'dannydwarren'
+                    Repo      = 'configurator'
+                    Extension = '.exe'
+                }
             }
+
+            $result = New-GitHubAssetApp -RawApp $raw
+
+            $result.InstallScript | Should -Be ''
+            $result.VerificationScript | Should -BeNullOrEmpty
+            $result.UpgradeScript | Should -BeNullOrEmpty
+            $result.PreventUpgrade | Should -BeTrue
+            $result.IsDownloadApp | Should -BeTrue
+            $result.Downloader | Should -Be 'GitHubAssetDownloader'
         }
-
-        $result = New-GitHubAssetApp -RawApp $raw
-
-        $result.InstallScript | Should -Be ''
-        $result.VerificationScript | Should -BeNullOrEmpty
-        $result.UpgradeScript | Should -BeNullOrEmpty
-        $result.PreventUpgrade | Should -BeTrue
-        $result.IsDownloadApp | Should -BeTrue
-        $result.Downloader | Should -Be 'GitHubAssetDownloader'
     }
 }

--- a/configurator-pwsh/tests/Unit/Private/Initialize.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Initialize.Tests.ps1
@@ -1,0 +1,233 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Initialize-System' {
+    It 'executes all 9 initialization steps in order' {
+        InModuleScope Configurator {
+            $script:callOrder = @()
+            Mock Set-PowerShellPolicy { $script:callOrder += "SetPolicy-$Edition" }
+            Mock Set-WingetConfiguration { $script:callOrder += "Winget-$Action" }
+            Mock Install-PowerShellCore { $script:callOrder += 'InstallPSCore' }
+            Mock Install-Self { $script:callOrder += 'InstallSelf' }
+            Mock Install-ScoopCli { $script:callOrder += 'InstallScoop' }
+            Mock Install-Git { $script:callOrder += 'InstallGit' }
+            Mock Install-ManifestRepo { $script:callOrder += 'InstallManifestRepo' }
+
+            Initialize-System
+
+            $script:callOrder.Count | Should -Be 9
+            $script:callOrder[0] | Should -Be 'SetPolicy-Windows'
+            $script:callOrder[1] | Should -Be 'Winget-Upgrade'
+            $script:callOrder[2] | Should -Be 'Winget-AcceptSourceAgreements'
+            $script:callOrder[3] | Should -Be 'InstallPSCore'
+            $script:callOrder[4] | Should -Be 'SetPolicy-Core'
+            $script:callOrder[5] | Should -Be 'InstallSelf'
+            $script:callOrder[6] | Should -Be 'InstallScoop'
+            $script:callOrder[7] | Should -Be 'InstallGit'
+            $script:callOrder[8] | Should -Be 'InstallManifestRepo'
+        }
+    }
+}
+
+Describe 'Set-PowerShellPolicy' {
+    It 'sets PS Core execution policy via admin and reports policy and version' {
+        InModuleScope Configurator {
+            Mock Invoke-PowerShellScript {}
+            Mock Invoke-PowerShellScript { return 'RemoteSigned' } -ParameterFilter { $null -ne $ResultType -and $Script -eq 'Get-ExecutionPolicy' }
+            Mock Invoke-PowerShellScript { return '7.4.0' } -ParameterFilter { $null -ne $ResultType -and $Script -eq '$PSVersionTable.PSVersion.ToString()' }
+            Mock Write-ConfiguratorLog {}
+
+            Set-PowerShellPolicy -Edition Core
+
+            Should -Invoke Invoke-PowerShellScript -ParameterFilter { $RunAsAdmin -eq $true -and $Script -eq 'Set-ExecutionPolicy RemoteSigned -Force' } -Times 1
+            Should -Invoke Invoke-PowerShellScript -ParameterFilter { $null -ne $ResultType -and $Script -eq 'Get-ExecutionPolicy' } -Times 1
+            Should -Invoke Invoke-PowerShellScript -ParameterFilter { $null -ne $ResultType -and $Script -eq '$PSVersionTable.PSVersion.ToString()' } -Times 1
+        }
+    }
+
+    It 'sets Windows PowerShell execution policy via admin and reports policy and version' {
+        InModuleScope Configurator {
+            Mock Invoke-WindowsPowerShellScript {}
+            Mock Invoke-WindowsPowerShellScript { return 'RemoteSigned' } -ParameterFilter { $null -ne $ResultType -and $Script -eq 'Get-ExecutionPolicy' }
+            Mock Invoke-WindowsPowerShellScript { return '5.1.0' } -ParameterFilter { $null -ne $ResultType -and $Script -eq '$PSVersionTable.PSVersion.ToString()' }
+            Mock Write-ConfiguratorLog {}
+
+            Set-PowerShellPolicy -Edition Windows
+
+            Should -Invoke Invoke-WindowsPowerShellScript -ParameterFilter { $RunAsAdmin -eq $true -and $Script -eq 'Set-ExecutionPolicy RemoteSigned -Force' } -Times 1
+            Should -Invoke Invoke-WindowsPowerShellScript -ParameterFilter { $null -ne $ResultType -and $Script -eq 'Get-ExecutionPolicy' } -Times 1
+            Should -Invoke Invoke-WindowsPowerShellScript -ParameterFilter { $null -ne $ResultType -and $Script -eq '$PSVersionTable.PSVersion.ToString()' } -Times 1
+        }
+    }
+}
+
+Describe 'Set-WingetConfiguration' {
+    It 'executes two Add-AppxPackage commands for Upgrade' {
+        InModuleScope Configurator {
+            $script:winScripts = @()
+            Mock Invoke-WindowsPowerShellScript { $script:winScripts += $Script }
+
+            Set-WingetConfiguration -Action Upgrade
+
+            $script:winScripts.Count | Should -Be 2
+            $script:winScripts[0] | Should -BeLike '*Microsoft.DesktopAppInstaller*msixbundle*'
+            $script:winScripts[1] | Should -BeLike '*source.msix*'
+        }
+    }
+
+    It 'executes winget list with accept-source-agreements for AcceptSourceAgreements' {
+        InModuleScope Configurator {
+            $script:winScripts = @()
+            Mock Invoke-WindowsPowerShellScript { $script:winScripts += $Script }
+
+            Set-WingetConfiguration -Action AcceptSourceAgreements
+
+            $script:winScripts.Count | Should -Be 1
+            $script:winScripts[0] | Should -BeLike '*winget list*--accept-source-agreements*'
+        }
+    }
+}
+
+Describe 'Install-PowerShellCore' {
+    It 'installs Microsoft.PowerShell WingetApp via ForceWindowsPowerShell' {
+        InModuleScope Configurator {
+            Mock Install-App {}
+            Mock Get-DesktopEntries { return @() }
+            Mock Remove-DesktopShortcuts {}
+
+            Install-PowerShellCore
+
+            Should -Invoke Install-App -Times 1 -ParameterFilter {
+                $App.AppId -eq 'Microsoft.PowerShell' -and
+                $App.AppType -eq 'winget' -and
+                $ForceWindowsPowerShell -eq $true
+            }
+        }
+    }
+}
+
+Describe 'Install-Self' {
+    It 'downloads Configurator from GitHub, moves to install dir, and adds to PATH' {
+        InModuleScope Configurator {
+            Mock Test-Path { return $false } -ParameterFilter { $Path -eq 'c:\Configurator' }
+            Mock Install-DownloadApp {
+                $App.DownloadedFilePath = 'C:\tmp\Configurator.exe'
+            }
+            Mock New-Item {}
+            Mock Move-Item {}
+            Mock Add-ToMachinePath {}
+            Mock Get-DesktopEntries { return @() }
+            Mock Remove-DesktopShortcuts {}
+
+            Install-Self
+
+            Should -Invoke Install-DownloadApp -Times 1 -ParameterFilter {
+                $App.AppId -eq 'Configurator' -and
+                $App.IsDownloadApp -eq $true
+            }
+            Should -Invoke New-Item -Times 1 -ParameterFilter { $Path -eq 'c:\Configurator' }
+            Should -Invoke Move-Item -Times 1
+            Should -Invoke Add-ToMachinePath -Times 1 -ParameterFilter { $Directory -eq 'c:\Configurator' }
+        }
+    }
+
+    It 'does nothing if install directory already exists' {
+        InModuleScope Configurator {
+            Mock Test-Path { return $true } -ParameterFilter { $Path -eq 'c:\Configurator' }
+            Mock Install-DownloadApp {}
+
+            Install-Self
+
+            Should -Invoke Install-DownloadApp -Times 0
+        }
+    }
+}
+
+Describe 'Install-ScoopCli' {
+    It 'installs ScriptApp with scoop install and verification scripts' {
+        InModuleScope Configurator {
+            Mock Install-App {}
+            Mock Get-DesktopEntries { return @() }
+            Mock Remove-DesktopShortcuts {}
+
+            Install-ScoopCli
+
+            Should -Invoke Install-App -Times 1 -ParameterFilter {
+                $App.AppId -eq 'ScoopCli' -and
+                $App.AppType -eq 'script' -and
+                $App.InstallScript -like '*get.scoop.sh*' -and
+                $App.VerificationScript -like '*Test-CommandExists scoop*'
+            }
+        }
+    }
+}
+
+Describe 'Install-Git' {
+    It 'installs Git.Git via Winget' {
+        InModuleScope Configurator {
+            Mock Install-App {}
+            Mock Get-DesktopEntries { return @() }
+            Mock Remove-DesktopShortcuts {}
+
+            Install-Git
+
+            Should -Invoke Install-App -Times 1 -ParameterFilter {
+                $App.AppId -eq 'Git.Git' -and
+                $App.AppType -eq 'winget'
+            }
+        }
+    }
+}
+
+Describe 'Install-ManifestRepo' {
+    It 'installs git repo with manifest repo URL from settings' {
+        InModuleScope Configurator {
+            Mock Import-Settings {
+                return [PSCustomObject]@{
+                    downloadsDirectory = 'C:/tmp/configurator-downloads'
+                    manifest = [PSCustomObject]@{
+                        repo      = 'https://github.com/user/machine-configs.git'
+                        fileName  = 'manifest.json'
+                        directory = $null
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+            Mock Install-App {}
+            Mock Get-DesktopEntries { return @() }
+            Mock Remove-DesktopShortcuts {}
+
+            Install-ManifestRepo
+
+            Should -Invoke Install-App -Times 1 -ParameterFilter {
+                $App.AppId -eq 'git.manifest-repo' -and
+                $App.AppType -eq 'gitRepo' -and
+                $App.InstallArgs -eq 'https://github.com/user/machine-configs.git'
+            }
+        }
+    }
+
+    It 'throws if manifest.repo setting is null' {
+        InModuleScope Configurator {
+            Mock Import-Settings {
+                return [PSCustomObject]@{
+                    downloadsDirectory = 'C:/tmp/configurator-downloads'
+                    manifest = [PSCustomObject]@{
+                        repo      = $null
+                        fileName  = 'manifest.json'
+                        directory = $null
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            { Install-ManifestRepo } | Should -Throw '*Missing setting: Manifest.Repo*'
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Private/Installer.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Installer.Tests.ps1
@@ -1,0 +1,363 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Install-App' {
+    It 'installs when app is not yet installed' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            $script:verifyCallCount = 0
+            Mock Invoke-PowerShellScript {
+                if ($ResultType -eq [bool]) {
+                    $script:verifyCallCount++
+                    if ($script:verifyCallCount -eq 1) { return $false }
+                    return $true
+                }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Invoke Invoke-PowerShellScript -Times 3 -Exactly
+            Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq "Installing 'test-app'" }
+            Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq "Installed 'test-app'" }
+        }
+    }
+
+    It 'uses Windows PowerShell when ForceWindowsPowerShell is set' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-WindowsPowerShellScript {
+                if ($ResultType -eq [bool]) { return $false }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app -ForceWindowsPowerShell
+
+            Should -Invoke Invoke-WindowsPowerShellScript -Times 3 -Exactly
+        }
+    }
+
+    It 'skips verification when no verification script' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-PowerShellScript {}
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Invoke Invoke-PowerShellScript -Times 1 -Exactly -ParameterFilter { $Script -eq 'install-script' }
+        }
+    }
+
+    It 'does not call Remove-DesktopShortcuts when nothing added to desktop' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-PowerShellScript {}
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Invoke Remove-DesktopShortcuts -Times 1 -Exactly -ParameterFilter {
+                $BeforeEntries.Count -eq 0 -and $AfterEntries.Count -eq 0
+            }
+        }
+    }
+
+    It 'upgrades when already installed' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = 'upgrade-script'
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-PowerShellScript {
+                if ($ResultType -eq [bool]) { return $true }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Invoke Invoke-PowerShellScript -ParameterFilter { $Script -eq 'upgrade-script' }
+        }
+    }
+
+    It 'prevents upgrade when PreventUpgrade is true' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = 'upgrade-script'
+                PreventUpgrade     = $true
+            }
+
+            Mock Invoke-PowerShellScript {
+                if ($ResultType -eq [bool]) { return $true }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Not -Invoke Invoke-PowerShellScript -ParameterFilter { $Script -eq 'upgrade-script' }
+            Should -Not -Invoke Invoke-PowerShellScript -ParameterFilter { $Script -eq 'install-script' }
+        }
+    }
+
+    It 'does nothing when already installed with no upgrade script' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-PowerShellScript {
+                if ($ResultType -eq [bool]) { return $true }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Not -Invoke Invoke-PowerShellScript -ParameterFilter { $Script -eq 'install-script' }
+        }
+    }
+
+    It 'logs debug when post-install verification fails' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'test-app'
+                InstallScript      = 'install-script'
+                VerificationScript = 'verify-script'
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Invoke-PowerShellScript {
+                if ($ResultType -eq [bool]) { return $false }
+            }
+            Mock Get-DesktopEntries { @() }
+            Mock Remove-DesktopShortcuts {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-App -App $app
+
+            Should -Invoke Write-ConfiguratorLog -ParameterFilter {
+                $Message -eq "Failed to install 'test-app'" -and $Level -eq 'Debug'
+            }
+        }
+    }
+}
+
+Describe 'Install-DownloadApp' {
+    It 'downloads and delegates to Install-App' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'download-app'
+                AppType            = 'gitHubAsset'
+                Downloader         = 'GitHubAssetDownloader'
+                DownloaderArgs     = [PSCustomObject]@{ User = 'user'; Repo = 'repo'; Extension = '.exe' }
+                DownloadedFilePath = $null
+                InstallScript      = 'install'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+            }
+
+            Mock Get-GitHubAsset { return 'C:\downloads\file.exe' }
+            Mock Install-App {}
+            Mock Write-ConfiguratorLog {}
+
+            Install-DownloadApp -App $app
+
+            $app.DownloadedFilePath | Should -Be 'C:\downloads\file.exe'
+            Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq "Downloading 'download-app'" }
+            Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq "Downloaded 'download-app'" }
+            Should -Invoke Install-App -Times 1 -Exactly
+        }
+    }
+}
+
+Describe 'Invoke-AppConfigurator' {
+    Context 'Configure' {
+        It 'sets registry values from configuration' {
+            InModuleScope Configurator {
+                $app = [PSCustomObject]@{
+                    AppId         = 'config-app'
+                    Configuration = [PSCustomObject]@{
+                        registrySettings = @(
+                            [PSCustomObject]@{ keyName = 'HKCU\Test'; valueName = 'Setting1'; valueData = 'Value1' }
+                            [PSCustomObject]@{ keyName = 'HKCU\Test'; valueName = 'Setting2'; valueData = 'Value2' }
+                        )
+                    }
+                }
+
+                Mock Set-RegistryValue {}
+
+                Invoke-AppConfigurator -App $app -Configure
+
+                Should -Invoke Set-RegistryValue -Times 2 -Exactly
+            }
+        }
+
+        It 'does nothing when configuration is null' {
+            InModuleScope Configurator {
+                $app = [PSCustomObject]@{
+                    AppId         = 'no-config-app'
+                    Configuration = $null
+                }
+
+                Mock Set-RegistryValue {}
+
+                Invoke-AppConfigurator -App $app -Configure
+
+                Should -Not -Invoke Set-RegistryValue
+            }
+        }
+    }
+
+    Context 'Backup' {
+        It 'backs up an installed app with backup script' {
+            InModuleScope Configurator {
+                $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-backup-test-$([guid]::NewGuid().ToString('N'))"
+                $appDir = Join-Path $testDir 'apps' 'backup-app'
+                New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+                Set-Content -Path (Join-Path $appDir 'backup.ps1') -Value 'Write-Host "backup"'
+
+                $app = [PSCustomObject]@{
+                    AppId              = 'backup-app'
+                    VerificationScript = 'verify-script'
+                }
+
+                Mock Invoke-PowerShellScript {
+                    if ($ResultType -eq [bool]) { return $true }
+                }
+                Mock Import-Settings {
+                    [PSCustomObject]@{
+                        manifest = [PSCustomObject]@{ directory = $testDir }
+                    }
+                }
+                Mock Write-ConfiguratorLog {}
+
+                Invoke-AppConfigurator -App $app -Backup
+
+                Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq 'Backing up backup-app...' }
+                Should -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -eq 'Backed up backup-app!' }
+
+                Remove-Item -Path $testDir -Recurse -Force
+            }
+        }
+
+        It 'skips when no verification script' {
+            InModuleScope Configurator {
+                $app = [PSCustomObject]@{
+                    AppId              = 'no-verify-app'
+                    VerificationScript = $null
+                }
+
+                Mock Invoke-PowerShellScript {}
+                Mock Import-Settings {}
+                Mock Write-ConfiguratorLog {}
+
+                Invoke-AppConfigurator -App $app -Backup
+
+                Should -Not -Invoke Invoke-PowerShellScript
+            }
+        }
+
+        It 'skips when app is not installed' {
+            InModuleScope Configurator {
+                $app = [PSCustomObject]@{
+                    AppId              = 'not-installed-app'
+                    VerificationScript = 'verify-script'
+                }
+
+                Mock Invoke-PowerShellScript {
+                    if ($ResultType -eq [bool]) { return $false }
+                }
+                Mock Import-Settings {}
+                Mock Write-ConfiguratorLog {}
+
+                Invoke-AppConfigurator -App $app -Backup
+
+                Should -Not -Invoke Import-Settings
+            }
+        }
+
+        It 'skips when backup script does not exist' {
+            InModuleScope Configurator {
+                $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-backup-test-$([guid]::NewGuid().ToString('N'))"
+                New-Item -Path $testDir -ItemType Directory -Force | Out-Null
+
+                $app = [PSCustomObject]@{
+                    AppId              = 'no-backup-script-app'
+                    VerificationScript = 'verify-script'
+                }
+
+                Mock Invoke-PowerShellScript {
+                    if ($ResultType -eq [bool]) { return $true }
+                }
+                Mock Import-Settings {
+                    [PSCustomObject]@{
+                        manifest = [PSCustomObject]@{ directory = $testDir }
+                    }
+                }
+                Mock Write-ConfiguratorLog {}
+
+                Invoke-AppConfigurator -App $app -Backup
+
+                Should -Not -Invoke Write-ConfiguratorLog -ParameterFilter { $Message -like 'Backing up*' }
+
+                Remove-Item -Path $testDir -Recurse -Force
+            }
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Private/Manifest.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Manifest.Tests.ps1
@@ -5,220 +5,317 @@ BeforeAll {
 
 Describe 'Import-AppDefinition' {
     It 'loads app.json and returns raw PSCustomObject' {
-        $testDir = Join-Path $TestDrive 'manifest'
-        $appDir = Join-Path $testDir 'apps' 'test-app'
-        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+        InModuleScope Configurator {
+            $testDir = Join-Path $TestDrive 'manifest'
+            $appDir = Join-Path $testDir 'apps' 'test-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
 
-        $appJson = @{
-            appType      = 'winget'
-            appId        = 'test-app'
-            environments = 'Work'
-            installArgs  = 'some-args'
-        } | ConvertTo-Json
-        Set-Content -Path (Join-Path $appDir 'app.json') -Value $appJson
+            $appJson = @{
+                appType      = 'winget'
+                appId        = 'test-app'
+                environments = 'Work'
+                installArgs  = 'some-args'
+            } | ConvertTo-Json
+            Set-Content -Path (Join-Path $appDir 'app.json') -Value $appJson
 
-        $result = Import-AppDefinition -AppId 'test-app' -ManifestDirectory $testDir
+            $result = Import-AppDefinition -AppId 'test-app' -ManifestDirectory $testDir
 
-        $result.appType | Should -Be 'winget'
-        $result.appId | Should -Be 'test-app'
-        $result.environments | Should -Be 'Work'
-        $result.installArgs | Should -Be 'some-args'
+            $result.appType | Should -Be 'winget'
+            $result.appId | Should -Be 'test-app'
+            $result.environments | Should -Be 'Work'
+            $result.installArgs | Should -Be 'some-args'
+        }
     }
 }
 
 Describe 'ConvertTo-AppObject' {
-    BeforeAll {
-        $settings = [PSCustomObject]@{
-            manifest = [PSCustomObject]@{
-                directory = $TestDrive
-                fileName  = 'manifest.json'
-            }
-            git = [PSCustomObject]@{
-                cloneDirectory = 'C:\src\'
-            }
-        }
-    }
-
     It 'routes winget app type correctly' {
-        $raw = [PSCustomObject]@{
-            appType      = 'winget'
-            appId        = 'Some.App'
-            environments = 'Work'
-            installArgs  = $null
-            preventUpgrade = $false
-            configuration = $null
+        InModuleScope Configurator {
+            $settings = [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $TestDrive
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+
+            $raw = [PSCustomObject]@{
+                appType        = 'winget'
+                appId          = 'Some.App'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+            $result.AppType | Should -Be 'winget'
+            $result.AppId | Should -Be 'Some.App'
+            $result.InstallScript | Should -BeLike 'winget install*Some.App*'
         }
-
-        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
-
-        $result.AppType | Should -Be 'winget'
-        $result.AppId | Should -Be 'Some.App'
-        $result.InstallScript | Should -BeLike 'winget install*Some.App*'
     }
 
     It 'routes scoop app type correctly' {
-        $raw = [PSCustomObject]@{
-            appType      = 'scoop'
-            appId        = '7zip'
-            environments = 'Work'
-            installArgs  = $null
-            preventUpgrade = $false
-            configuration = $null
+        InModuleScope Configurator {
+            $settings = [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $TestDrive
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+
+            $raw = [PSCustomObject]@{
+                appType        = 'scoop'
+                appId          = '7zip'
+                environments   = 'Work'
+                installArgs    = $null
+                preventUpgrade = $false
+                configuration  = $null
+            }
+
+            $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+            $result.AppType | Should -Be 'scoop'
+            $result.InstallScript | Should -BeLike 'scoop install*7zip*'
         }
-
-        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
-
-        $result.AppType | Should -Be 'scoop'
-        $result.InstallScript | Should -BeLike 'scoop install*7zip*'
     }
 
     It 'returns null for unknown app type' {
-        $raw = [PSCustomObject]@{
-            appType      = 'unknown'
-            appId        = 'bad-app'
-            environments = 'Work'
+        InModuleScope Configurator {
+            $settings = [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $TestDrive
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+
+            $raw = [PSCustomObject]@{
+                appType      = 'unknown'
+                appId        = 'bad-app'
+                environments = 'Work'
+            }
+
+            $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+            $result | Should -BeNullOrEmpty
         }
-
-        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
-
-        $result | Should -BeNullOrEmpty
     }
 }
 
 Describe 'Import-Manifest' {
-    BeforeAll {
-        $manifestDir = Join-Path $TestDrive 'manifest-load'
-        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
-
-        $app1Dir = Join-Path $manifestDir 'apps' 'winget-app'
-        New-Item -Path $app1Dir -ItemType Directory -Force | Out-Null
-        @{ appType = 'winget'; appId = 'winget-app'; environments = 'Work' } |
-            ConvertTo-Json | Set-Content -Path (Join-Path $app1Dir 'app.json')
-
-        $app2Dir = Join-Path $manifestDir 'apps' 'scoop-app'
-        New-Item -Path $app2Dir -ItemType Directory -Force | Out-Null
-        @{ appType = 'scoop'; appId = 'scoop-app'; environments = 'Personal' } |
-            ConvertTo-Json | Set-Content -Path (Join-Path $app2Dir 'app.json')
-
-        @{ apps = @('winget-app', 'scoop-app') } |
-            ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
-    }
-
     It 'loads all apps when no environments specified' {
-        Mock Import-Settings {
-            [PSCustomObject]@{
-                manifest = [PSCustomObject]@{
-                    directory = $manifestDir
-                    fileName  = 'manifest.json'
-                }
-                git = [PSCustomObject]@{
-                    cloneDirectory = 'C:\src\'
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'manifest-load-all'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+            $app1Dir = Join-Path $manifestDir 'apps' 'winget-app'
+            New-Item -Path $app1Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'winget'; appId = 'winget-app'; environments = 'Work' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app1Dir 'app.json')
+
+            $app2Dir = Join-Path $manifestDir 'apps' 'scoop-app'
+            New-Item -Path $app2Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'scoop'; appId = 'scoop-app'; environments = 'Personal' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app2Dir 'app.json')
+
+            @{ apps = @('winget-app', 'scoop-app') } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
                 }
             }
+
+            $result = Import-Manifest
+
+            $result.AppIds.Count | Should -Be 2
+            $result.Apps.Count | Should -Be 2
         }
-
-        $result = Import-Manifest
-
-        $result.AppIds.Count | Should -Be 2
-        $result.Apps.Count | Should -Be 2
     }
 
     It 'filters apps by environment' {
-        Mock Import-Settings {
-            [PSCustomObject]@{
-                manifest = [PSCustomObject]@{
-                    directory = $manifestDir
-                    fileName  = 'manifest.json'
-                }
-                git = [PSCustomObject]@{
-                    cloneDirectory = 'C:\src\'
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'manifest-load-filter'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+            $app1Dir = Join-Path $manifestDir 'apps' 'winget-app'
+            New-Item -Path $app1Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'winget'; appId = 'winget-app'; environments = 'Work' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app1Dir 'app.json')
+
+            $app2Dir = Join-Path $manifestDir 'apps' 'scoop-app'
+            New-Item -Path $app2Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'scoop'; appId = 'scoop-app'; environments = 'Personal' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app2Dir 'app.json')
+
+            @{ apps = @('winget-app', 'scoop-app') } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
                 }
             }
+
+            $result = Import-Manifest -Environments @('Work')
+
+            $result.Apps.Count | Should -Be 1
+            $result.Apps[0].AppId | Should -Be 'winget-app'
         }
-
-        $result = Import-Manifest -Environments @('Work')
-
-        $result.Apps.Count | Should -Be 1
-        $result.Apps[0].AppId | Should -Be 'winget-app'
     }
 
     It 'loads single app by ID' {
-        Mock Import-Settings {
-            [PSCustomObject]@{
-                manifest = [PSCustomObject]@{
-                    directory = $manifestDir
-                    fileName  = 'manifest.json'
-                }
-                git = [PSCustomObject]@{
-                    cloneDirectory = 'C:\src\'
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'manifest-load-single'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+            $app1Dir = Join-Path $manifestDir 'apps' 'winget-app'
+            New-Item -Path $app1Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'winget'; appId = 'winget-app'; environments = 'Work' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app1Dir 'app.json')
+
+            $app2Dir = Join-Path $manifestDir 'apps' 'scoop-app'
+            New-Item -Path $app2Dir -ItemType Directory -Force | Out-Null
+            @{ appType = 'scoop'; appId = 'scoop-app'; environments = 'Personal' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $app2Dir 'app.json')
+
+            @{ apps = @('winget-app', 'scoop-app') } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
                 }
             }
+
+            $result = Import-Manifest -SingleAppId 'scoop-app'
+
+            $result.Apps.Count | Should -Be 1
+            $result.Apps[0].AppId | Should -Be 'scoop-app'
         }
+    }
 
-        $result = Import-Manifest -SingleAppId 'scoop-app'
+    It 'excludes unknown app types' {
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'manifest-load-unknown'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
 
-        $result.Apps.Count | Should -Be 1
-        $result.Apps[0].AppId | Should -Be 'scoop-app'
+            $appDir = Join-Path $manifestDir 'apps' 'unknown-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+            @{ appType = 'unknown'; appId = 'unknown-app'; environments = 'Work' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $appDir 'app.json')
+
+            @{ apps = @('unknown-app') } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
+                }
+            }
+
+            $result = Import-Manifest
+
+            $result.Apps.Count | Should -Be 0
+        }
     }
 }
 
 Describe 'Save-AppDefinition' {
     It 'creates app directory and writes app.json' {
-        $manifestDir = Join-Path $TestDrive 'save-test'
-        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
-        @{ apps = @() } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'save-test'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+            @{ apps = @() } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
 
-        Mock Import-Settings {
-            [PSCustomObject]@{
-                manifest = [PSCustomObject]@{
-                    directory = $manifestDir
-                    fileName  = 'manifest.json'
-                }
-                git = [PSCustomObject]@{
-                    cloneDirectory = 'C:\src\'
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
                 }
             }
+
+            Save-AppDefinition -AppId 'new-app' -AppType 'winget' -Environments 'Work|Personal'
+
+            $appFile = Join-Path $manifestDir 'apps' 'new-app' 'app.json'
+            Test-Path $appFile | Should -BeTrue
+
+            $appData = Get-Content $appFile -Raw | ConvertFrom-Json
+            $appData.appType | Should -Be 'winget'
+            $appData.appId | Should -Be 'new-app'
+            $appData.environments | Should -Be 'Work|Personal'
+
+            $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
+            $manifest.apps | Should -Contain 'new-app'
         }
-
-        Save-AppDefinition -AppId 'new-app' -AppType 'winget' -Environments 'Work|Personal'
-
-        $appFile = Join-Path $manifestDir 'apps' 'new-app' 'app.json'
-        Test-Path $appFile | Should -BeTrue
-
-        $appData = Get-Content $appFile -Raw | ConvertFrom-Json
-        $appData.appType | Should -Be 'winget'
-        $appData.appId | Should -Be 'new-app'
-        $appData.environments | Should -Be 'Work|Personal'
-
-        $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
-        $manifest.apps | Should -Contain 'new-app'
     }
 
     It 'is idempotent - does not duplicate app' {
-        $manifestDir = Join-Path $TestDrive 'save-idempotent'
-        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
-        @{ apps = @('existing-app') } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+        InModuleScope Configurator {
+            $manifestDir = Join-Path $TestDrive 'save-idempotent'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+            @{ apps = @('existing-app') } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
 
-        $appDir = Join-Path $manifestDir 'apps' 'existing-app'
-        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
-        @{ appType = 'winget'; appId = 'existing-app'; environments = 'Work' } |
-            ConvertTo-Json | Set-Content -Path (Join-Path $appDir 'app.json')
+            $appDir = Join-Path $manifestDir 'apps' 'existing-app'
+            New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+            @{ appType = 'winget'; appId = 'existing-app'; environments = 'Work' } |
+                ConvertTo-Json | Set-Content -Path (Join-Path $appDir 'app.json')
 
-        Mock Import-Settings {
-            [PSCustomObject]@{
-                manifest = [PSCustomObject]@{
-                    directory = $manifestDir
-                    fileName  = 'manifest.json'
-                }
-                git = [PSCustomObject]@{
-                    cloneDirectory = 'C:\src\'
+            Mock Import-Settings {
+                [PSCustomObject]@{
+                    manifest = [PSCustomObject]@{
+                        directory = $manifestDir
+                        fileName  = 'manifest.json'
+                    }
+                    git = [PSCustomObject]@{
+                        cloneDirectory = 'C:\src\'
+                    }
                 }
             }
+
+            Save-AppDefinition -AppId 'existing-app' -AppType 'winget' -Environments 'Work'
+
+            $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
+            @($manifest.apps).Count | Should -Be 1
         }
-
-        Save-AppDefinition -AppId 'existing-app' -AppType 'winget' -Environments 'Work'
-
-        $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
-        @($manifest.apps).Count | Should -Be 1
     }
 }

--- a/configurator-pwsh/tests/Unit/Private/Manifest.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Manifest.Tests.ps1
@@ -1,0 +1,224 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Import-AppDefinition' {
+    It 'loads app.json and returns raw PSCustomObject' {
+        $testDir = Join-Path $TestDrive 'manifest'
+        $appDir = Join-Path $testDir 'apps' 'test-app'
+        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+
+        $appJson = @{
+            appType      = 'winget'
+            appId        = 'test-app'
+            environments = 'Work'
+            installArgs  = 'some-args'
+        } | ConvertTo-Json
+        Set-Content -Path (Join-Path $appDir 'app.json') -Value $appJson
+
+        $result = Import-AppDefinition -AppId 'test-app' -ManifestDirectory $testDir
+
+        $result.appType | Should -Be 'winget'
+        $result.appId | Should -Be 'test-app'
+        $result.environments | Should -Be 'Work'
+        $result.installArgs | Should -Be 'some-args'
+    }
+}
+
+Describe 'ConvertTo-AppObject' {
+    BeforeAll {
+        $settings = [PSCustomObject]@{
+            manifest = [PSCustomObject]@{
+                directory = $TestDrive
+                fileName  = 'manifest.json'
+            }
+            git = [PSCustomObject]@{
+                cloneDirectory = 'C:\src\'
+            }
+        }
+    }
+
+    It 'routes winget app type correctly' {
+        $raw = [PSCustomObject]@{
+            appType      = 'winget'
+            appId        = 'Some.App'
+            environments = 'Work'
+            installArgs  = $null
+            preventUpgrade = $false
+            configuration = $null
+        }
+
+        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+        $result.AppType | Should -Be 'winget'
+        $result.AppId | Should -Be 'Some.App'
+        $result.InstallScript | Should -BeLike 'winget install*Some.App*'
+    }
+
+    It 'routes scoop app type correctly' {
+        $raw = [PSCustomObject]@{
+            appType      = 'scoop'
+            appId        = '7zip'
+            environments = 'Work'
+            installArgs  = $null
+            preventUpgrade = $false
+            configuration = $null
+        }
+
+        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+        $result.AppType | Should -Be 'scoop'
+        $result.InstallScript | Should -BeLike 'scoop install*7zip*'
+    }
+
+    It 'returns null for unknown app type' {
+        $raw = [PSCustomObject]@{
+            appType      = 'unknown'
+            appId        = 'bad-app'
+            environments = 'Work'
+        }
+
+        $result = ConvertTo-AppObject -RawApp $raw -Settings $settings
+
+        $result | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Import-Manifest' {
+    BeforeAll {
+        $manifestDir = Join-Path $TestDrive 'manifest-load'
+        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+        $app1Dir = Join-Path $manifestDir 'apps' 'winget-app'
+        New-Item -Path $app1Dir -ItemType Directory -Force | Out-Null
+        @{ appType = 'winget'; appId = 'winget-app'; environments = 'Work' } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $app1Dir 'app.json')
+
+        $app2Dir = Join-Path $manifestDir 'apps' 'scoop-app'
+        New-Item -Path $app2Dir -ItemType Directory -Force | Out-Null
+        @{ appType = 'scoop'; appId = 'scoop-app'; environments = 'Personal' } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $app2Dir 'app.json')
+
+        @{ apps = @('winget-app', 'scoop-app') } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+    }
+
+    It 'loads all apps when no environments specified' {
+        Mock Import-Settings {
+            [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $manifestDir
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+        }
+
+        $result = Import-Manifest
+
+        $result.AppIds.Count | Should -Be 2
+        $result.Apps.Count | Should -Be 2
+    }
+
+    It 'filters apps by environment' {
+        Mock Import-Settings {
+            [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $manifestDir
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+        }
+
+        $result = Import-Manifest -Environments @('Work')
+
+        $result.Apps.Count | Should -Be 1
+        $result.Apps[0].AppId | Should -Be 'winget-app'
+    }
+
+    It 'loads single app by ID' {
+        Mock Import-Settings {
+            [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $manifestDir
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+        }
+
+        $result = Import-Manifest -SingleAppId 'scoop-app'
+
+        $result.Apps.Count | Should -Be 1
+        $result.Apps[0].AppId | Should -Be 'scoop-app'
+    }
+}
+
+Describe 'Save-AppDefinition' {
+    It 'creates app directory and writes app.json' {
+        $manifestDir = Join-Path $TestDrive 'save-test'
+        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+        @{ apps = @() } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+        Mock Import-Settings {
+            [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $manifestDir
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+        }
+
+        Save-AppDefinition -AppId 'new-app' -AppType 'winget' -Environments 'Work|Personal'
+
+        $appFile = Join-Path $manifestDir 'apps' 'new-app' 'app.json'
+        Test-Path $appFile | Should -BeTrue
+
+        $appData = Get-Content $appFile -Raw | ConvertFrom-Json
+        $appData.appType | Should -Be 'winget'
+        $appData.appId | Should -Be 'new-app'
+        $appData.environments | Should -Be 'Work|Personal'
+
+        $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
+        $manifest.apps | Should -Contain 'new-app'
+    }
+
+    It 'is idempotent - does not duplicate app' {
+        $manifestDir = Join-Path $TestDrive 'save-idempotent'
+        New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+        @{ apps = @('existing-app') } | ConvertTo-Json | Set-Content -Path (Join-Path $manifestDir 'manifest.json')
+
+        $appDir = Join-Path $manifestDir 'apps' 'existing-app'
+        New-Item -Path $appDir -ItemType Directory -Force | Out-Null
+        @{ appType = 'winget'; appId = 'existing-app'; environments = 'Work' } |
+            ConvertTo-Json | Set-Content -Path (Join-Path $appDir 'app.json')
+
+        Mock Import-Settings {
+            [PSCustomObject]@{
+                manifest = [PSCustomObject]@{
+                    directory = $manifestDir
+                    fileName  = 'manifest.json'
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+        }
+
+        Save-AppDefinition -AppId 'existing-app' -AppType 'winget' -Environments 'Work'
+
+        $manifest = Get-Content (Join-Path $manifestDir 'manifest.json') -Raw | ConvertFrom-Json
+        @($manifest.apps).Count | Should -Be 1
+    }
+}

--- a/configurator-pwsh/tests/Unit/Private/Settings.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Settings.Tests.ps1
@@ -1,0 +1,156 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Get-SettingsPath' {
+    It 'returns the correct settings file path' {
+        $result = InModuleScope Configurator { Get-SettingsPath }
+        $expected = Join-Path $env:LOCALAPPDATA 'Configurator' 'settings.json'
+        $result | Should -Be $expected
+    }
+}
+
+Describe 'Import-Settings' {
+    BeforeAll {
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-settings-tests-$([guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:testRoot -ItemType Directory -Force | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path $script:testRoot) {
+            Remove-Item -Path $script:testRoot -Recurse -Force
+        }
+    }
+
+    It 'creates directory and default settings file on first load' {
+        $settingsDir = Join-Path $script:testRoot 'first-load'
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+        $downloadsDir = Join-Path $script:testRoot 'downloads'
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath; downloadsDir = $downloadsDir } {
+            param($settingsPath, $downloadsDir)
+            Mock Get-SettingsPath { return $settingsPath }
+
+            $result = Import-Settings
+
+            $result.downloadsDirectory | Should -Be 'C:/tmp/configurator-downloads'
+            $result.manifest.fileName | Should -Be 'manifest.json'
+            $result.manifest.repo | Should -BeNullOrEmpty
+            $result.manifest.directory | Should -BeNullOrEmpty
+            $result.git.cloneDirectory | Should -Be 'C:\src\'
+
+            Test-Path $settingsPath | Should -BeTrue
+        }
+    }
+
+    It 'loads existing settings from disk' {
+        $settingsDir = Join-Path $script:testRoot 'existing'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        $existingSettings = @{
+            downloadsDirectory = 'D:/my-downloads'
+            manifest = @{
+                repo = 'https://github.com/user/repo.git'
+                fileName = 'custom-manifest.json'
+                directory = 'D:\repos\my-config'
+            }
+            git = @{
+                cloneDirectory = 'D:\repos\'
+            }
+        } | ConvertTo-Json -Depth 10
+        Set-Content -Path $settingsPath -Value $existingSettings -Encoding UTF8
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath } {
+            param($settingsPath)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $result = Import-Settings
+
+            $result.downloadsDirectory | Should -Be 'D:/my-downloads'
+            $result.manifest.repo | Should -Be 'https://github.com/user/repo.git'
+            $result.manifest.fileName | Should -Be 'custom-manifest.json'
+            $result.manifest.directory | Should -Be 'D:\repos\my-config'
+            $result.git.cloneDirectory | Should -Be 'D:\repos\'
+        }
+    }
+}
+
+Describe 'Export-Settings' {
+    BeforeAll {
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-export-tests-$([guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:testRoot -ItemType Directory -Force | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path $script:testRoot) {
+            Remove-Item -Path $script:testRoot -Recurse -Force
+        }
+    }
+
+    It 'writes JSON to settings path and ensures downloads directory' {
+        $settingsDir = Join-Path $script:testRoot 'export'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        $settings = [PSCustomObject]@{
+            downloadsDirectory = 'C:/tmp/configurator-downloads'
+            manifest = [PSCustomObject]@{
+                repo = $null
+                fileName = 'manifest.json'
+                directory = $null
+            }
+            git = [PSCustomObject]@{
+                cloneDirectory = 'C:\src\'
+            }
+        }
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath; settings = $settings } {
+            param($settingsPath, $settings)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            Export-Settings -Settings $settings
+
+            Test-Path $settingsPath | Should -BeTrue
+            $written = Get-Content -Path $settingsPath -Raw | ConvertFrom-Json
+            $written.downloadsDirectory | Should -Be 'C:/tmp/configurator-downloads'
+            $written.manifest.fileName | Should -Be 'manifest.json'
+        }
+    }
+
+    It 'round-trips: save then load returns same values' {
+        $settingsDir = Join-Path $script:testRoot 'roundtrip'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        $settings = [PSCustomObject]@{
+            downloadsDirectory = 'C:/tmp/configurator-downloads'
+            manifest = [PSCustomObject]@{
+                repo = 'https://github.com/test/repo.git'
+                fileName = 'my-manifest.json'
+                directory = 'C:\repos\test'
+            }
+            git = [PSCustomObject]@{
+                cloneDirectory = 'C:\code\'
+            }
+        }
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath; settings = $settings } {
+            param($settingsPath, $settings)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            Export-Settings -Settings $settings
+            $loaded = Import-Settings
+
+            $loaded.downloadsDirectory | Should -Be $settings.downloadsDirectory
+            $loaded.manifest.repo | Should -Be $settings.manifest.repo
+            $loaded.manifest.fileName | Should -Be $settings.manifest.fileName
+            $loaded.manifest.directory | Should -Be $settings.manifest.directory
+            $loaded.git.cloneDirectory | Should -Be $settings.git.cloneDirectory
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Private/Utilities.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Private/Utilities.Tests.ps1
@@ -1,0 +1,208 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Write-ConfiguratorLog' {
+    It 'writes formatted log message with correct level label' {
+        InModuleScope Configurator {
+            Mock Write-Host {}
+
+            Write-ConfiguratorLog -Message 'test message' -Level Info
+
+            Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter {
+                $Object -match '^\[.+\] \[INFO \] test message$' -and $ForegroundColor -eq 'White'
+            }
+        }
+    }
+
+    It 'uses correct color for each level' {
+        InModuleScope Configurator {
+            $levels = @{
+                Debug    = 'Gray'
+                Verbose  = 'White'
+                Info     = 'White'
+                Warn     = 'Yellow'
+                Error    = 'Red'
+                Progress = 'Blue'
+                Result   = 'Green'
+            }
+
+            foreach ($level in $levels.Keys) {
+                Mock Write-Host {}
+
+                Write-ConfiguratorLog -Message 'test' -Level $level
+
+                Should -Invoke Write-Host -ParameterFilter { $ForegroundColor -eq $levels[$level] }
+            }
+        }
+    }
+
+    It 'uses ISO8601 timestamp format' {
+        InModuleScope Configurator {
+            Mock Write-Host {}
+
+            Write-ConfiguratorLog -Message 'ts test' -Level Info
+
+            Should -Invoke Write-Host -ParameterFilter {
+                $Object -match '^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}'
+            }
+        }
+    }
+}
+
+Describe 'Resolve-Token' {
+    It 'resolves a single env token' {
+        InModuleScope Configurator {
+            $programFiles = [System.Environment]::GetEnvironmentVariable('ProgramFiles')
+            $result = Resolve-Token -Value '{{env:ProgramFiles}}\path'
+            $result | Should -Be "$programFiles\path"
+        }
+    }
+
+    It 'resolves multiple env tokens' {
+        InModuleScope Configurator {
+            $programFiles = [System.Environment]::GetEnvironmentVariable('ProgramFiles')
+            $userProfile = [System.Environment]::GetEnvironmentVariable('USERPROFILE')
+            $result = Resolve-Token -Value '{{env:ProgramFiles}}\app and {{env:USERPROFILE}}\data'
+            $result | Should -Be "$programFiles\app and $userProfile\data"
+        }
+    }
+
+    It 'replaces unknown env var with empty string' {
+        InModuleScope Configurator {
+            $result = Resolve-Token -Value '{{env:NONEXISTENT_VAR_12345}}\path'
+            $result | Should -Be '\path'
+        }
+    }
+
+    It 'returns value unchanged when no tokens present' {
+        InModuleScope Configurator {
+            $result = Resolve-Token -Value 'no tokens here'
+            $result | Should -Be 'no tokens here'
+        }
+    }
+}
+
+Describe 'Get-DesktopEntries' {
+    It 'returns entries from both desktop paths' {
+        InModuleScope Configurator {
+            $result = Get-DesktopEntries
+            $result | Should -Not -BeNullOrEmpty -Because 'desktop directories typically have entries'
+        }
+    }
+}
+
+Describe 'Remove-DesktopShortcuts' {
+    It 'deletes new entries that appear after install' {
+        InModuleScope Configurator {
+            $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "desktop-test-$([guid]::NewGuid().ToString('N'))"
+            New-Item -Path $testDir -ItemType Directory -Force | Out-Null
+            $newFile = Join-Path $testDir 'new-shortcut.lnk'
+            Set-Content -Path $newFile -Value 'test'
+
+            $before = @()
+            $after = @($newFile)
+
+            Remove-DesktopShortcuts -BeforeEntries $before -AfterEntries $after
+
+            Test-Path $newFile | Should -BeFalse
+
+            Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It 'does not delete existing entries' {
+        InModuleScope Configurator {
+            $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "desktop-test-$([guid]::NewGuid().ToString('N'))"
+            New-Item -Path $testDir -ItemType Directory -Force | Out-Null
+            $existingFile = Join-Path $testDir 'existing.lnk'
+            Set-Content -Path $existingFile -Value 'test'
+
+            $before = @($existingFile)
+            $after = @($existingFile)
+
+            Remove-DesktopShortcuts -BeforeEntries $before -AfterEntries $after
+
+            Test-Path $existingFile | Should -BeTrue
+
+            Remove-Item -Path $testDir -Recurse -Force
+        }
+    }
+}
+
+Describe 'Test-Administrator' {
+    It 'returns a boolean value' {
+        InModuleScope Configurator {
+            $result = Test-Administrator
+            $result | Should -BeOfType [bool]
+        }
+    }
+}
+
+Describe 'Get-Download' {
+    It 'throws on non-200 status' {
+        InModuleScope Configurator {
+            $testDir = Join-Path ([System.IO.Path]::GetTempPath()) "download-test-$([guid]::NewGuid().ToString('N'))"
+            New-Item -Path $testDir -ItemType Directory -Force | Out-Null
+
+            Mock Invoke-WebRequest { throw "404 not found" }
+
+            { Get-Download -Url 'https://invalid.example.com/file.exe' -FileName 'file.exe' -DownloadsDirectory $testDir } |
+                Should -Throw
+
+            Remove-Item -Path $testDir -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Describe 'New-ScriptFile' {
+    It 'writes script to temp file and returns path' {
+        InModuleScope Configurator {
+            $result = New-ScriptFile -Script 'Write-Host "hello"'
+
+            $result | Should -Match '\.ps1$'
+            Test-Path $result | Should -BeTrue
+            $content = Get-Content -Path $result -Raw
+            $content | Should -Match 'Write-Host "hello"'
+
+            Remove-Item -Path $result -Force
+        }
+    }
+
+    It 'creates file in Configurator temp directory' {
+        InModuleScope Configurator {
+            $result = New-ScriptFile -Script 'test'
+            $expectedDir = Join-Path $env:LOCALAPPDATA 'Configurator' 'temp'
+            $result | Should -BeLike "$expectedDir*"
+
+            Remove-Item -Path $result -Force
+        }
+    }
+
+    It 'uses timestamp format in filename' {
+        InModuleScope Configurator {
+            $result = New-ScriptFile -Script 'test'
+            $fileName = [System.IO.Path]::GetFileNameWithoutExtension($result)
+            $fileName | Should -Match '^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d{5}$'
+
+            Remove-Item -Path $result -Force
+        }
+    }
+}
+
+Describe 'Find-PowerShellCore' {
+    It 'returns a path to pwsh.exe when PowerShell Core is installed' {
+        InModuleScope Configurator {
+            $regKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SOFTWARE\Microsoft\PowerShellCore\InstalledVersions')
+            if ($null -eq $regKey) {
+                Set-ItResult -Skipped -Because 'PowerShell Core registry key not found'
+                return
+            }
+            $regKey.Close()
+
+            $result = Find-PowerShellCore
+            $result | Should -Match 'pwsh\.exe$'
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/AddApp.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/AddApp.Tests.ps1
@@ -1,0 +1,43 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Add-ConfiguratorApp' {
+    BeforeEach {
+        Mock Save-AppDefinition {}
+    }
+
+    It 'joins environments with pipe and calls Save-AppDefinition for winget app' {
+        Add-ConfiguratorApp -AppId 'Some.WingetApp' -AppType 'winget' -Environments @('Work', 'Personal')
+
+        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+            $AppId -eq 'Some.WingetApp' -and
+            $AppType -eq 'winget' -and
+            $Environments -eq 'Work|Personal'
+        }
+    }
+
+    It 'joins environments with pipe and calls Save-AppDefinition for scoop app' {
+        Add-ConfiguratorApp -AppId 'some-scoop-app' -AppType 'scoop' -Environments @('Dev', 'Test')
+
+        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+            $AppId -eq 'some-scoop-app' -and
+            $AppType -eq 'scoop' -and
+            $Environments -eq 'Dev|Test'
+        }
+    }
+
+    It 'handles single environment' {
+        Add-ConfiguratorApp -AppId 'single-env-app' -AppType 'gitconfig' -Environments @('Work')
+
+        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+            $Environments -eq 'Work'
+        }
+    }
+
+    It 'rejects invalid app types' {
+        { Add-ConfiguratorApp -AppId 'bad' -AppType 'invalidType' -Environments @('Work') } |
+            Should -Throw
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/AddApp.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/AddApp.Tests.ps1
@@ -5,34 +5,42 @@ BeforeAll {
 
 Describe 'Add-ConfiguratorApp' {
     BeforeEach {
-        Mock Save-AppDefinition {}
+        InModuleScope Configurator {
+            Mock Save-AppDefinition {}
+        }
     }
 
     It 'joins environments with pipe and calls Save-AppDefinition for winget app' {
         Add-ConfiguratorApp -AppId 'Some.WingetApp' -AppType 'winget' -Environments @('Work', 'Personal')
 
-        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
-            $AppId -eq 'Some.WingetApp' -and
-            $AppType -eq 'winget' -and
-            $Environments -eq 'Work|Personal'
+        InModuleScope Configurator {
+            Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+                $AppId -eq 'Some.WingetApp' -and
+                $AppType -eq 'winget' -and
+                $Environments -eq 'Work|Personal'
+            }
         }
     }
 
     It 'joins environments with pipe and calls Save-AppDefinition for scoop app' {
         Add-ConfiguratorApp -AppId 'some-scoop-app' -AppType 'scoop' -Environments @('Dev', 'Test')
 
-        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
-            $AppId -eq 'some-scoop-app' -and
-            $AppType -eq 'scoop' -and
-            $Environments -eq 'Dev|Test'
+        InModuleScope Configurator {
+            Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+                $AppId -eq 'some-scoop-app' -and
+                $AppType -eq 'scoop' -and
+                $Environments -eq 'Dev|Test'
+            }
         }
     }
 
     It 'handles single environment' {
         Add-ConfiguratorApp -AppId 'single-env-app' -AppType 'gitconfig' -Environments @('Work')
 
-        Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
-            $Environments -eq 'Work'
+        InModuleScope Configurator {
+            Should -Invoke Save-AppDefinition -Times 1 -ParameterFilter {
+                $Environments -eq 'Work'
+            }
         }
     }
 

--- a/configurator-pwsh/tests/Unit/Public/Backup.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/Backup.Tests.ps1
@@ -1,0 +1,56 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Invoke-Backup' {
+    It 'loads full manifest and calls backup for each app' {
+        InModuleScope Configurator {
+            $app1 = [PSCustomObject]@{
+                AppId              = 'app-1'
+                VerificationScript = 'verify-1'
+            }
+            $app2 = [PSCustomObject]@{
+                AppId              = 'app-2'
+                VerificationScript = 'verify-2'
+            }
+
+            Mock Import-Manifest {
+                @{
+                    AppIds = @('app-1', 'app-2')
+                    Apps   = @($app1, $app2)
+                }
+            }
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-Backup
+
+            Should -Invoke Import-Manifest -Times 1 -Exactly -ParameterFilter {
+                $Environments.Count -eq 0
+            }
+            Should -Invoke Invoke-AppConfigurator -Times 2 -Exactly
+            Should -Invoke Invoke-AppConfigurator -ParameterFilter {
+                $App.AppId -eq 'app-1' -and $Backup -eq $true
+            }
+            Should -Invoke Invoke-AppConfigurator -ParameterFilter {
+                $App.AppId -eq 'app-2' -and $Backup -eq $true
+            }
+        }
+    }
+
+    It 'handles manifest with no apps' {
+        InModuleScope Configurator {
+            Mock Import-Manifest {
+                @{
+                    AppIds = @()
+                    Apps   = @()
+                }
+            }
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-Backup
+
+            Should -Not -Invoke Invoke-AppConfigurator
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/Cli.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/Cli.Tests.ps1
@@ -1,0 +1,322 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Start-Configurator' {
+    Context 'Privilege check' {
+        It 'returns exit code 2 when not elevated' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $false }
+                Mock Write-ConfiguratorLog {}
+
+                $result = Start-Configurator -Command 'initialize'
+
+                $result | Should -Be 2
+                Should -Invoke Write-ConfiguratorLog -ParameterFilter {
+                    $Message -eq 'Configurator Cli must be run with elevated privileges.' -and $Level -eq 'Error'
+                }
+            }
+        }
+    }
+
+    Context 'No arguments' {
+        It 'shows help and returns exit code 0' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Write-Host {}
+
+                $result = Start-Configurator
+
+                $result | Should -Be 0
+                Should -Invoke Write-Host -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'Invalid command' {
+        It 'returns exit code 1 for unknown command' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Write-ConfiguratorLog {}
+
+                $result = Start-Configurator -Command 'invalid-arg'
+
+                $result | Should -Be 1
+                Should -Invoke Write-ConfiguratorLog -ParameterFilter {
+                    $Message -eq 'Unknown command: invalid-arg' -and $Level -eq 'Error'
+                }
+            }
+        }
+    }
+
+    Context 'initialize command' {
+        It 'executes initialize and returns 0' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-Initialize {}
+
+                $result = Start-Configurator -Command 'initialize'
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-Initialize -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'settings list command' {
+        It 'executes list settings and returns 0' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Get-ConfiguratorSettings {}
+
+                $result = Start-Configurator -Command 'settings' -RemainingArgs @('list')
+
+                $result | Should -Be 0
+                Should -Invoke Get-ConfiguratorSettings -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'settings set command' {
+        It 'executes set setting with both args and returns 0' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Set-ConfiguratorSetting {}
+
+                $result = Start-Configurator -Command 'settings' -RemainingArgs @('set', 'manifest.repo', 'https://github.com/user/repo.git')
+
+                $result | Should -Be 0
+                Should -Invoke Set-ConfiguratorSetting -Times 1 -Exactly -ParameterFilter {
+                    $Name -eq 'manifest.repo' -and $Value -eq 'https://github.com/user/repo.git'
+                }
+            }
+        }
+
+        It 'returns exit code 1 when missing arguments' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Write-ConfiguratorLog {}
+
+                $result = Start-Configurator -Command 'settings' -RemainingArgs @('set', 'manifest.repo')
+
+                $result | Should -Be 1
+            }
+        }
+    }
+
+    Context 'settings with no subcommand' {
+        It 'returns exit code 1' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Write-Host {}
+
+                $result = Start-Configurator -Command 'settings'
+
+                $result | Should -Be 1
+            }
+        }
+    }
+
+    Context 'add-app command' {
+        It 'parses pipe-separated environments and executes add-app' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Add-ConfiguratorApp {}
+
+                $result = Start-Configurator -Command 'add-app' -RemainingArgs @(
+                    '--app-id', 'my-app',
+                    '--app-type', 'winget',
+                    '--environments', 'Work|Personal'
+                )
+
+                $result | Should -Be 0
+                Should -Invoke Add-ConfiguratorApp -Times 1 -Exactly -ParameterFilter {
+                    $AppId -eq 'my-app' -and $AppType -eq 'winget'
+                }
+            }
+        }
+
+        It 'returns exit code 1 when missing required args' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Write-ConfiguratorLog {}
+
+                $result = Start-Configurator -Command 'add-app' -RemainingArgs @('--app-id', 'my-app')
+
+                $result | Should -Be 1
+            }
+        }
+    }
+
+    Context 'add command (alias)' {
+        It 'works the same as add-app' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Add-ConfiguratorApp {}
+
+                $result = Start-Configurator -Command 'add' -RemainingArgs @(
+                    '--app-id', 'my-app',
+                    '--app-type', 'scoop',
+                    '--environments', 'Dev'
+                )
+
+                $result | Should -Be 0
+                Should -Invoke Add-ConfiguratorApp -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'configure-machine command' {
+        It 'executes with empty environment list and no single app' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure-machine'
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'configure command (alias)' {
+        It 'works the same as configure-machine' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure'
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'configure --single-app-id' {
+        It 'passes the single app ID' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure' -RemainingArgs @('--single-app-id', 'my-app')
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly -ParameterFilter {
+                    $SingleAppId -eq 'my-app'
+                }
+            }
+        }
+    }
+
+    Context 'configure -app (alias)' {
+        It 'passes the single app ID via -app alias' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure' -RemainingArgs @('-app', 'my-app')
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly -ParameterFilter {
+                    $SingleAppId -eq 'my-app'
+                }
+            }
+        }
+    }
+
+    Context 'configure --environments' {
+        It 'parses pipe-separated environments' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure' -RemainingArgs @('--environments', 'Work|Personal')
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly -ParameterFilter {
+                    $Environments.Count -eq 2 -and $Environments[0] -eq 'Work' -and $Environments[1] -eq 'Personal'
+                }
+            }
+        }
+    }
+
+    Context 'configure -e (alias)' {
+        It 'parses environments via -e alias' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-ConfigureMachine {}
+
+                $result = Start-Configurator -Command 'configure' -RemainingArgs @('-e', 'Dev|Staging')
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-ConfigureMachine -Times 1 -Exactly -ParameterFilter {
+                    $Environments.Count -eq 2 -and $Environments[0] -eq 'Dev' -and $Environments[1] -eq 'Staging'
+                }
+            }
+        }
+    }
+
+    Context 'backup command' {
+        It 'executes backup and returns 0' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-Backup {}
+
+                $result = Start-Configurator -Command 'backup'
+
+                $result | Should -Be 0
+                Should -Invoke Invoke-Backup -Times 1 -Exactly
+            }
+        }
+    }
+
+    Context 'command throws exception' {
+        It 'catches exception and returns exit code 1' {
+            InModuleScope Configurator {
+                Mock Test-Administrator { return $true }
+                Mock Invoke-Initialize { throw 'Something went wrong' }
+                Mock Write-ConfiguratorLog {}
+
+                $result = Start-Configurator -Command 'initialize'
+
+                $result | Should -Be 1
+                Should -Invoke Write-ConfiguratorLog -ParameterFilter {
+                    $Message -eq 'Something went wrong' -and $Level -eq 'Error'
+                }
+            }
+        }
+    }
+}
+
+Describe 'Get-NamedArgValue' {
+    It 'extracts value for matching arg name' {
+        InModuleScope Configurator {
+            $result = Get-NamedArgValue -ArgList @('--name', 'value') -Names @('--name')
+            $result | Should -Be 'value'
+        }
+    }
+
+    It 'returns null when arg not found' {
+        InModuleScope Configurator {
+            $result = Get-NamedArgValue -ArgList @('--other', 'value') -Names @('--name')
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'handles null arg list' {
+        InModuleScope Configurator {
+            $result = Get-NamedArgValue -ArgList $null -Names @('--name')
+            $result | Should -BeNullOrEmpty
+        }
+    }
+
+    It 'matches first of multiple aliases' {
+        InModuleScope Configurator {
+            $result = Get-NamedArgValue -ArgList @('-e', 'envs') -Names @('--environments', '-e')
+            $result | Should -Be 'envs'
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/ConfigureMachine.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/ConfigureMachine.Tests.ps1
@@ -1,0 +1,196 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Invoke-ConfigureMachine' {
+    It 'installs all manifest apps and configures each' {
+        InModuleScope Configurator {
+            $app1 = [PSCustomObject]@{
+                AppId              = 'app-1'
+                AppType            = 'winget'
+                IsDownloadApp      = $false
+                InstallScript      = 'install-1'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+                Configuration      = $null
+            }
+            $app2 = [PSCustomObject]@{
+                AppId              = 'app-2'
+                AppType            = 'scoop'
+                IsDownloadApp      = $false
+                InstallScript      = 'install-2'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+                Configuration      = $null
+            }
+
+            Mock Import-Manifest {
+                @{
+                    AppIds = @('app-1', 'app-2')
+                    Apps   = @($app1, $app2)
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine -Environments @('Work')
+
+            Should -Invoke Import-Manifest -Times 1 -Exactly -ParameterFilter {
+                $Environments.Count -eq 1 -and $Environments[0] -eq 'Work'
+            }
+            Should -Invoke Install-App -Times 2 -Exactly
+            Should -Not -Invoke Install-DownloadApp
+            Should -Invoke Invoke-AppConfigurator -Times 2 -Exactly
+            Should -Invoke Invoke-AppConfigurator -ParameterFilter {
+                $App.AppId -eq 'app-1' -and $Configure -eq $true
+            }
+            Should -Invoke Invoke-AppConfigurator -ParameterFilter {
+                $App.AppId -eq 'app-2' -and $Configure -eq $true
+            }
+        }
+    }
+
+    It 'uses Install-DownloadApp for download apps' {
+        InModuleScope Configurator {
+            $downloadApp = [PSCustomObject]@{
+                AppId              = 'download-app'
+                AppType            = 'powerShellAppPackage'
+                IsDownloadApp      = $true
+                Downloader         = 'GitHubAssetDownloader'
+                DownloaderArgs     = [PSCustomObject]@{ User = 'u'; Repo = 'r'; Extension = '.exe' }
+                DownloadedFilePath = $null
+                InstallScript      = 'install'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+                Configuration      = $null
+            }
+            $normalApp = [PSCustomObject]@{
+                AppId              = 'normal-app'
+                AppType            = 'winget'
+                IsDownloadApp      = $false
+                InstallScript      = 'install'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+                Configuration      = $null
+            }
+
+            Mock Import-Manifest {
+                @{
+                    AppIds = @('download-app', 'normal-app')
+                    Apps   = @($downloadApp, $normalApp)
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine
+
+            Should -Invoke Install-DownloadApp -Times 1 -Exactly -ParameterFilter {
+                $App.AppId -eq 'download-app'
+            }
+            Should -Invoke Install-App -Times 1 -Exactly -ParameterFilter {
+                $App.AppId -eq 'normal-app'
+            }
+        }
+    }
+
+    It 'loads single app by ID when SingleAppId is provided' {
+        InModuleScope Configurator {
+            $app = [PSCustomObject]@{
+                AppId              = 'single-app'
+                AppType            = 'winget'
+                IsDownloadApp      = $false
+                InstallScript      = 'install'
+                VerificationScript = $null
+                UpgradeScript      = $null
+                PreventUpgrade     = $false
+                Configuration      = $null
+            }
+
+            Mock Import-Manifest {
+                @{
+                    AppIds = @('single-app')
+                    Apps   = @($app)
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine -SingleAppId 'single-app'
+
+            Should -Invoke Import-Manifest -Times 1 -Exactly -ParameterFilter {
+                $SingleAppId -eq 'single-app'
+            }
+            Should -Invoke Install-App -Times 1 -Exactly
+            Should -Invoke Invoke-AppConfigurator -Times 1 -Exactly
+        }
+    }
+
+    It 'handles empty manifest' {
+        InModuleScope Configurator {
+            Mock Import-Manifest {
+                @{
+                    AppIds = @()
+                    Apps   = @()
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine
+
+            Should -Not -Invoke Install-App
+            Should -Not -Invoke Install-DownloadApp
+            Should -Not -Invoke Invoke-AppConfigurator
+        }
+    }
+
+    It 'passes multiple environments to Import-Manifest' {
+        InModuleScope Configurator {
+            Mock Import-Manifest {
+                @{
+                    AppIds = @()
+                    Apps   = @()
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine -Environments @('Work', 'Personal')
+
+            Should -Invoke Import-Manifest -Times 1 -Exactly -ParameterFilter {
+                $Environments.Count -eq 2
+            }
+        }
+    }
+
+    It 'defaults to empty environments when none specified' {
+        InModuleScope Configurator {
+            Mock Import-Manifest {
+                @{
+                    AppIds = @()
+                    Apps   = @()
+                }
+            }
+            Mock Install-App {}
+            Mock Install-DownloadApp {}
+            Mock Invoke-AppConfigurator {}
+
+            Invoke-ConfigureMachine
+
+            Should -Invoke Import-Manifest -Times 1 -Exactly -ParameterFilter {
+                $Environments.Count -eq 0
+            }
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/Initialize.Commands.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/Initialize.Commands.Tests.ps1
@@ -1,0 +1,156 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Invoke-Initialize' {
+    It 'runs system initializer, sets manifest directory, clones repo, creates manifest file' {
+        InModuleScope Configurator {
+            $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-init-test-$([guid]::NewGuid().ToString('N'))"
+            $cloneDir = Join-Path $testRoot 'src'
+            New-Item -Path $cloneDir -ItemType Directory -Force | Out-Null
+
+            $settingsDir = Join-Path $testRoot 'settings'
+            New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+            $settingsPath = Join-Path $settingsDir 'settings.json'
+
+            Mock Initialize-System {}
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo      = 'https://github.com/user/machine-configs.git'
+                    fileName  = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = $cloneDir
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+            Mock Export-Settings {}
+            Mock Test-Path { return $false }
+            Mock Invoke-PowerShellScript {}
+            Mock Set-Content {}
+
+            Invoke-Initialize
+
+            Should -Invoke Initialize-System -Times 1
+            Should -Invoke Export-Settings -Times 1
+            Should -Invoke Invoke-PowerShellScript -Times 2
+
+            $mockSettings.manifest.directory | Should -Not -BeNullOrEmpty
+
+            try { Remove-Item -Path $testRoot -Recurse -Force } catch {}
+        }
+    }
+
+    It 'creates and commits manifest file when it does not exist' {
+        InModuleScope Configurator {
+            $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-init-newmanifest-$([guid]::NewGuid().ToString('N'))"
+            $cloneDir = Join-Path $testRoot 'src'
+            $manifestDir = Join-Path $cloneDir 'machine-configs'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+            $settingsDir = Join-Path $testRoot 'settings'
+            New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+            $settingsPath = Join-Path $settingsDir 'settings.json'
+
+            Mock Initialize-System {}
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo      = 'https://github.com/user/machine-configs.git'
+                    fileName  = 'manifest.json'
+                    directory = $manifestDir
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = $cloneDir
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+            Mock Export-Settings {}
+            Mock Test-Path { return $true } -ParameterFilter { $Path -eq $manifestDir }
+            Mock Test-Path { return $false } -ParameterFilter { $Path -ne $manifestDir }
+            Mock Invoke-PowerShellScript {}
+            Mock Set-Content {}
+
+            Invoke-Initialize
+
+            Should -Invoke Invoke-PowerShellScript -Times 1 -ParameterFilter {
+                $Script -like '*git add*' -and $Script -like '*git commit*' -and $Script -like '*git push*'
+            }
+            Should -Invoke Set-Content -Times 1
+
+            try { Remove-Item -Path $testRoot -Recurse -Force } catch {}
+        }
+    }
+
+    It 'does nothing when manifest directory and file already exist' {
+        InModuleScope Configurator {
+            $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-init-exists-$([guid]::NewGuid().ToString('N'))"
+            $cloneDir = Join-Path $testRoot 'src'
+            $manifestDir = Join-Path $cloneDir 'machine-configs'
+            New-Item -Path $manifestDir -ItemType Directory -Force | Out-Null
+
+            $settingsDir = Join-Path $testRoot 'settings'
+            New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+            $settingsPath = Join-Path $settingsDir 'settings.json'
+
+            Mock Initialize-System {}
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo      = 'https://github.com/user/machine-configs.git'
+                    fileName  = 'manifest.json'
+                    directory = $manifestDir
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = $cloneDir
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+            Mock Export-Settings {}
+            Mock Test-Path { return $true }
+            Mock Invoke-PowerShellScript {}
+            Mock Set-Content {}
+
+            Invoke-Initialize
+
+            Should -Invoke Invoke-PowerShellScript -Times 0
+            Should -Invoke Set-Content -Times 0
+
+            try { Remove-Item -Path $testRoot -Recurse -Force } catch {}
+        }
+    }
+
+    It 'throws if manifest.repo setting is null' {
+        InModuleScope Configurator {
+            Mock Initialize-System {}
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo      = $null
+                    fileName  = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+
+            { Invoke-Initialize } | Should -Throw "*manifest.repo*must be set*"
+        }
+    }
+}

--- a/configurator-pwsh/tests/Unit/Public/Settings.Commands.Tests.ps1
+++ b/configurator-pwsh/tests/Unit/Public/Settings.Commands.Tests.ps1
@@ -1,0 +1,161 @@
+BeforeAll {
+    $modulePath = Join-Path $PSScriptRoot '..' '..' '..' 'src' 'Configurator.psd1'
+    Import-Module $modulePath -Force
+}
+
+Describe 'Get-ConfiguratorSettings' {
+    It 'lists all setting paths with correct names and types' {
+        InModuleScope Configurator {
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo = $null
+                    fileName = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+
+            $rows = Get-SettingRows -Node $mockSettings -Prefix ''
+
+            $rows.Count | Should -Be 5
+
+            $dlRow = $rows | Where-Object { $_.Name -eq 'downloadsdirectory' }
+            $dlRow.Value | Should -Be 'C:/tmp/configurator-downloads'
+            $dlRow.Type | Should -Be 'Uri'
+
+            $repoRow = $rows | Where-Object { $_.Name -eq 'manifest.repo' }
+            $repoRow.Value | Should -Be ''
+            $repoRow.Type | Should -Be 'Uri'
+
+            $fileRow = $rows | Where-Object { $_.Name -eq 'manifest.filename' }
+            $fileRow.Value | Should -Be 'manifest.json'
+            $fileRow.Type | Should -Be 'String'
+
+            $dirRow = $rows | Where-Object { $_.Name -eq 'manifest.directory' }
+            $dirRow.Value | Should -Be ''
+            $dirRow.Type | Should -Be 'String'
+
+            $gitRow = $rows | Where-Object { $_.Name -eq 'git.clonedirectory' }
+            $gitRow.Value | Should -Be 'C:\src\'
+            $gitRow.Type | Should -Be 'Uri'
+        }
+    }
+}
+
+Describe 'Set-ConfiguratorSetting' {
+    BeforeAll {
+        $script:testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "configurator-setcmd-tests-$([guid]::NewGuid().ToString('N'))"
+        New-Item -Path $script:testRoot -ItemType Directory -Force | Out-Null
+    }
+
+    AfterAll {
+        if (Test-Path $script:testRoot) {
+            Remove-Item -Path $script:testRoot -Recurse -Force
+        }
+    }
+
+    It 'updates manifest.repo with Uri value' {
+        $settingsDir = Join-Path $script:testRoot 'set-repo'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath } {
+            param($settingsPath)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo = $null
+                    fileName = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+
+            $exportedSettings = $null
+            Mock Export-Settings { $script:exportedSettings = $Settings }
+
+            Set-ConfiguratorSetting -Name 'manifest.repo' -Value 'https://github.com/user/repo.git'
+
+            $mockSettings.manifest.repo | Should -Not -BeNullOrEmpty
+            $mockSettings.manifest.repo.ToString() | Should -Be 'https://github.com/user/repo.git'
+            $mockSettings.manifest.repo | Should -BeOfType [uri]
+        }
+    }
+
+    It 'updates manifest.filename with string value' {
+        $settingsDir = Join-Path $script:testRoot 'set-filename'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath } {
+            param($settingsPath)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo = $null
+                    fileName = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+            Mock Export-Settings {}
+
+            Set-ConfiguratorSetting -Name 'manifest.filename' -Value 'custom.json'
+
+            $mockSettings.manifest.fileName | Should -Be 'custom.json'
+        }
+    }
+
+    It 'throws for unknown setting name' {
+        InModuleScope Configurator {
+            $mockSettings = [PSCustomObject]@{
+                downloadsDirectory = 'C:/tmp/configurator-downloads'
+                manifest = [PSCustomObject]@{
+                    repo = $null
+                    fileName = 'manifest.json'
+                    directory = $null
+                }
+                git = [PSCustomObject]@{
+                    cloneDirectory = 'C:\src\'
+                }
+            }
+            Mock Import-Settings { return $mockSettings }
+            Mock Export-Settings {}
+
+            { Set-ConfiguratorSetting -Name 'nonexistent.setting' -Value 'value' } | Should -Throw '*is not a recognized setting name*'
+        }
+    }
+
+    It 'persists value through save and reload' {
+        $settingsDir = Join-Path $script:testRoot 'set-persist'
+        New-Item -Path $settingsDir -ItemType Directory -Force | Out-Null
+        $settingsPath = Join-Path $settingsDir 'settings.json'
+
+        InModuleScope Configurator -Parameters @{ settingsPath = $settingsPath } {
+            param($settingsPath)
+            Mock Get-SettingsPath { return $settingsPath }
+            Mock New-Item {}
+
+            Set-ConfiguratorSetting -Name 'manifest.filename' -Value 'updated.json'
+
+            $loaded = Import-Settings
+            $loaded.manifest.fileName | Should -Be 'updated.json'
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Complete rewrite of the Configurator CLI from C# to pure PowerShell 7.0+ module
- All 6 CLI commands replicated: `initialize`, `configure-machine`, `settings list/set`, `add-app`, `backup`
- All 12 app types supported with identical manifest format (backward compatible with existing manifest repos)
- 165 Pester tests (127 unit + 38 integration) all passing
- 3 bugs from the C# version fixed (ScoopBucket verification, VS Extension typo, GitHubAsset spelling)
- New GitHub Action workflows for CI (Pester) and CD (module packaging + GitHub release)
- Bootstrap installer script for fresh machine setup
- Original C# README archived to `archive/README-csharp.md`

Closes #13, #14, #15, #16, #17, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28

## Structure

```
configurator-pwsh/
  spec/              # Behavior specification (contract for the rewrite)
  src/               # PowerShell module (52 functions)
    Configurator.ps1   # CLI entry point
    Configurator.psd1  # Module manifest
    Configurator.psm1  # Root module
    Public/            # 7 exported functions
    Private/           # 45 internal functions
  tests/             # Pester test suite
    Unit/              # 127 unit tests
    Integration/       # 38 integration tests + 52 test fixtures
  .github/workflows/  # CI + CD pipelines
  Install-Configurator.ps1  # Bootstrap installer
```

## Test plan

- [x] All 165 Pester tests pass (unit + integration)
- [x] All 12 app types produce correct install/verify/upgrade scripts
- [x] Settings format backward-compatible with C# version
- [x] Manifest loading with environment filtering matches C# behavior
- [x] CLI commands route correctly with aliases
- [x] Spec owner validated full implementation against behavioral specification
- [ ] Manual test: bootstrap install on a fresh machine
- [ ] Manual test: run against a real manifest repo (e.g., machine-configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)